### PR TITLE
dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(fcitx5-skey VERSION 0.7.5)
+project(fcitx5-skey VERSION 0.7.6)
 
 # Version compiled into the settings GUI / updater.  Dev builds append a
 # suffix (e.g. 0.7.5~dev.123) — project() VERSION must stay purely numeric,

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ SKey hỗ trợ **cập nhật tự động ngay trong giao diện** — không 
 1. Mở `fcitx5-skey-settings` → **Tab Info**
 2. Bấm **"Kiểm tra cập nhật"** — app truy vấn GitHub Releases API để so sánh phiên bản
 3. Nếu có phiên bản mới → hiện dialog với **version + release notes** → bấm **"Cập nhật ngay"**
-4. App tự động **tải .deb** → **cài qua `pkexec dpkg -i`** → **chạy `skey-setup`** → **restart Fcitx5** (có reconnect Wayland virtual keyboard)
+4. App tự động **tải .deb** → **cài qua `pkexec apt-get install -y`** (tự kéo thêm dependency mới như libqt6svg6) → **chạy `skey-setup`** → **restart Fcitx5** (có reconnect Wayland virtual keyboard)
 5. Settings GUI tự khởi động lại với phiên bản mới sau khi cài xong
 
 Toàn bộ quy trình diễn ra trong GUI — người dùng chỉ cần bấm 2 nút: "Kiểm tra cập nhật" → "Cập nhật ngay". Sau khi cập nhật, Fcitx5 được restart tự động và sẵn sàng sử dụng ngay.

--- a/build.sh
+++ b/build.sh
@@ -57,7 +57,9 @@ Version: $PKG_VERSION
 Section: utils
 Priority: optional
 Architecture: $PKG_ARCH
-Depends: fcitx5, systemd, hicolor-icon-theme, libqt6widgets6, libxcb1
+# libqt6svg6 = Qt6 SVG image plugin: the settings GUI loads SVG icons via
+# QIcon; without it the Icons tab (and system tray icon) render blank.
+Depends: fcitx5, systemd, hicolor-icon-theme, libqt6widgets6, libqt6svg6, libxcb1
 Maintainer: Huy
 Description: Vietnamese SKey input method addon for Fcitx5
  This package provides the skey input method engine for fcitx5,

--- a/build.sh
+++ b/build.sh
@@ -49,6 +49,9 @@ echo "--> Staging files for Debian package..."
 DESTDIR="$(pwd)/$PKG_DIR" cmake --install build-deb
 
 # Create DEBIAN folder and control file
+# NOTE: dpkg control files don't allow '#' comments inside the heredoc —
+# libqt6svg6 = Qt6 SVG image plugin: the settings GUI loads SVG icons via
+# QIcon; without it the Icons tab (and system tray icon) render blank.
 echo "--> Generating DEBIAN/control..."
 mkdir -p "$PKG_DIR/DEBIAN"
 cat <<EOF > "$PKG_DIR/DEBIAN/control"
@@ -57,8 +60,6 @@ Version: $PKG_VERSION
 Section: utils
 Priority: optional
 Architecture: $PKG_ARCH
-# libqt6svg6 = Qt6 SVG image plugin: the settings GUI loads SVG icons via
-# QIcon; without it the Icons tab (and system tray icon) render blank.
 Depends: fcitx5, systemd, hicolor-icon-theme, libqt6widgets6, libqt6svg6, libxcb1
 Maintainer: Huy
 Description: Vietnamese SKey input method addon for Fcitx5

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -24,24 +24,38 @@ install(FILES icons/fcitx-skey.svg
 install(FILES icons/fcitx-skey.svg
     DESTINATION "${CMAKE_INSTALL_DATADIR}/pixmaps"
     RENAME "fcitx-skey.svg")
-# Generate a 128px PNG for pixmaps (fallback for environments without QtSvg plugin)
+# Generate 128px PNG fallbacks for the default icon AND every preset, so
+# environments without the Qt SVG image plugin (libqt6svg6) still render
+# icons — QIcon loads PNG natively.  The resolver probes
+# hicolor/128x128/apps first, then scalable/apps, then pixmaps; without
+# these PNGs the preset tiles went blank when the SVG plugin was missing
+# (presets used to ship SVG-only).
 find_program(RSVG_CONVERT rsvg-convert)
 if(RSVG_CONVERT)
-    set(SVG_ICON "${CMAKE_CURRENT_SOURCE_DIR}/icons/fcitx-skey.svg")
-    set(PIXMAPS_PNG "${CMAKE_CURRENT_BINARY_DIR}/pixmaps/fcitx-skey.png")
-    add_custom_command(
-        OUTPUT ${PIXMAPS_PNG}
-        COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/pixmaps"
-        COMMAND ${RSVG_CONVERT} -w 128 -h 128 "${SVG_ICON}" -o ${PIXMAPS_PNG}
-        DEPENDS "${SVG_ICON}"
-        COMMENT "Generating 128x128 pixmaps icon"
-    )
-    install(FILES ${PIXMAPS_PNG}
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/pixmaps"
-        RENAME "fcitx-skey.png")
-    add_custom_target(skey_icons ALL DEPENDS ${PIXMAPS_PNG})
+    set(SKEY_PNG_ICONS fcitx-skey fcitx-skey-v-blue fcitx-skey-v-dark
+                       fcitx-skey-v-light fcitx-skey-v-red fcitx-skey-vn-flag)
+    set(SKEY_PNG_OUTPUTS)
+    foreach(ICON_NAME ${SKEY_PNG_ICONS})
+        set(PNG_OUT "${CMAKE_CURRENT_BINARY_DIR}/pixmaps/${ICON_NAME}.png")
+        add_custom_command(
+            OUTPUT ${PNG_OUT}
+            COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/pixmaps"
+            COMMAND ${RSVG_CONVERT} -w 128 -h 128
+                "${CMAKE_CURRENT_SOURCE_DIR}/icons/${ICON_NAME}.svg" -o ${PNG_OUT}
+            DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/icons/${ICON_NAME}.svg"
+            COMMENT "Generating 128x128 PNG fallback for ${ICON_NAME}"
+        )
+        list(APPEND SKEY_PNG_OUTPUTS ${PNG_OUT})
+        install(FILES ${PNG_OUT}
+            DESTINATION "${CMAKE_INSTALL_DATADIR}/icons/hicolor/128x128/apps"
+            RENAME "${ICON_NAME}.png")
+        install(FILES ${PNG_OUT}
+            DESTINATION "${CMAKE_INSTALL_DATADIR}/pixmaps"
+            RENAME "${ICON_NAME}.png")
+    endforeach()
+    add_custom_target(skey_icons ALL DEPENDS ${SKEY_PNG_OUTPUTS})
 else()
-    message(WARNING "rsvg-convert not found — PNG fallback icon will not be generated")
+    message(WARNING "rsvg-convert not found — PNG fallback icons will not be generated")
 endif()
 
 # status/ — KDE system tray (system tray uses 'status' icon context, not 'apps')

--- a/debian/control
+++ b/debian/control
@@ -28,6 +28,9 @@ Depends: ${shlibs:Depends},
          ${misc:Depends},
          fcitx5,
          hicolor-icon-theme,
+         # Qt6 SVG image plugin — the settings GUI loads SVG icons via QIcon;
+         # without it the Icons tab (and system tray icon) render blank.
+         libqt6svg6,
          acl,
          udev
 Description: Vietnamese SKey input method addon for Fcitx5

--- a/packaging/fcitx5-skey.spec
+++ b/packaging/fcitx5-skey.spec
@@ -254,7 +254,11 @@ fi
 %{_datadir}/icons/breeze/apps/*/fcitx-skey.svg
 %{_datadir}/icons/breeze-dark/status/*/fcitx-skey.svg
 %{_datadir}/icons/breeze-dark/apps/*/fcitx-skey.svg
+# 128px PNG fallbacks (rsvg-convert at build time) — renderable without
+# the Qt SVG image plugin.
+%{_datadir}/icons/hicolor/128x128/apps/fcitx-skey*.png
 %{_datadir}/pixmaps/fcitx-skey.*
+%{_datadir}/pixmaps/fcitx-skey*.png
 # Preset icons (v-blue, v-dark, v-light, v-red, vn-flag) — SVG only,
 # loaded at runtime by icon_resolver via absolute path.
 %{_datadir}/icons/hicolor/scalable/apps/fcitx-skey-v-*.svg

--- a/src/settings/updater.cpp
+++ b/src/settings/updater.cpp
@@ -360,7 +360,14 @@ void Updater::onDownloadFinished() {
 
     switch (distro_) {
     case Distro::Debian:
-        args = {"dpkg", "-i", pendingPackagePath_};
+        // apt-get resolves dependencies from the repos (e.g. libqt6svg6);
+        // plain `dpkg -i` fails with "dependency problems" whenever the
+        // new package adds a dependency the system doesn't have yet.
+        if (!QStandardPaths::findExecutable("apt-get").isEmpty()) {
+            args = {"apt-get", "install", "-y", pendingPackagePath_};
+        } else {
+            args = {"dpkg", "-i", pendingPackagePath_};
+        }
         break;
     case Distro::Fedora:
         // dnf install resolves dependencies automatically


### PR DESCRIPTION
- **fix: add libqt6svg6 dependency to ensure proper SVG icon rendering in settings GUI**
- **chore: move control file dependency comment outside of heredoc in build script**
- **chore: bump project version to 0.7.6**
- **fix: resolve dependency installation issues on Debian by preferring apt-get over dpkg**
- **feat: generate 128px PNG fallbacks for all preset icons to ensure rendering in environments missing the Qt SVG plugin**
