### PR TITLE
dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(fcitx5-skey VERSION 0.7.6)
+project(fcitx5-skey VERSION 0.7.7)
 
 # Version compiled into the settings GUI / updater.  Dev builds append a
 # suffix (e.g. 0.7.5~dev.123) — project() VERSION must stay purely numeric,

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ sudo nix flake update skey
 sudo nixos-rebuild switch --flake /etc/nixos
 ```
 
+Kênh **Thử nghiệm (Dev)** hoạt động đầy đủ trên NixOS: GUI pin flake input vào đúng tag dev prerelease + ghi `services.fcitx5-skey.devVersion` để build mang version string dev; quay lại Stable sẽ reset cả hai.
+
 > 💡 Hướng dẫn cấu hình thủ công chi tiết (kể cả hệ thống chưa dùng flake): [packaging/nixos/README.md](packaging/nixos/README.md). Để cập nhật qua GUI hoạt động, input trong flake phải tên là `skey`.
 
 > **GPG key fingerprint:** Tất cả repository (APT, RPM, Arch) dùng chung một GPG key. Public key tại `https://collyn.github.io/skey/key.asc`. Import thủ công: `curl -fsSL https://collyn.github.io/skey/key.asc | gpg --import`

--- a/README.md
+++ b/README.md
@@ -111,6 +111,24 @@ Cập nhật tự động qua `pacman -Syu`. Cần thêm frontends:
 sudo pacman -S fcitx5-gtk fcitx5-qt
 ```
 
+### NixOS
+
+```bash
+curl -fsSL https://collyn.github.io/skey/install-nixos.sh | sudo bash
+sudo nixos-rebuild switch --flake /etc/nixos
+```
+
+Script tự động sửa `/etc/nixos/flake.nix` (thêm input `skey` = `github:collyn/skey`, import module, thêm `skey` vào outputs) và thêm vào `/etc/nixos/configuration.nix` khối cấu hình: `services.fcitx5-skey` (uinput server cho user đang chạy script) + bật fcitx5 với addon SKey. Script idempotent — chạy lại không gây hại.
+
+Cập nhật: mở **fcitx5-skey-settings** → tab Thông tin → **Check Update** (GUI tự chạy `nix flake update skey` + `nixos-rebuild switch`), hoặc thủ công:
+
+```bash
+sudo nix flake update skey
+sudo nixos-rebuild switch --flake /etc/nixos
+```
+
+> 💡 Hướng dẫn cấu hình thủ công chi tiết (kể cả hệ thống chưa dùng flake): [packaging/nixos/README.md](packaging/nixos/README.md). Để cập nhật qua GUI hoạt động, input trong flake phải tên là `skey`.
+
 > **GPG key fingerprint:** Tất cả repository (APT, RPM, Arch) dùng chung một GPG key. Public key tại `https://collyn.github.io/skey/key.asc`. Import thủ công: `curl -fsSL https://collyn.github.io/skey/key.asc | gpg --import`
 
 ### Build từ source

--- a/README.md
+++ b/README.md
@@ -118,9 +118,9 @@ curl -fsSL https://collyn.github.io/skey/install-nixos.sh | sudo bash
 sudo nixos-rebuild switch --flake /etc/nixos
 ```
 
-Script tự động sửa `/etc/nixos/flake.nix` (thêm input `skey` = `github:collyn/skey`, import module, thêm `skey` vào outputs) và thêm vào `/etc/nixos/configuration.nix` khối cấu hình: `services.fcitx5-skey` (uinput server cho user đang chạy script) + bật fcitx5 với addon SKey. Script idempotent — chạy lại không gây hại.
+Script tự động sửa `/etc/nixos/flake.nix` (thêm input `skey` = `github:collyn/skey`, import module, thêm `skey` vào outputs) và thêm vào `/etc/nixos/configuration.nix` khối cấu hình: `services.fcitx5-skey` (uinput server cho user đang chạy script) + bật fcitx5 với addon SKey.
 
-Cập nhật: mở **fcitx5-skey-settings** → tab Thông tin → **Check Update** (GUI tự chạy `nix flake update skey` + `nixos-rebuild switch`), hoặc thủ công:
+Cập nhật: mở **fcitx5-skey-settings** → tab Info → **Check Update** (GUI tự chạy `nix flake update skey` + `nixos-rebuild switch`), hoặc thủ công:
 
 ```bash
 sudo nix flake update skey

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787135253,
+        "narHash": "sha256-RD2kNWCG+Bjo6h+JVjWVNntZs2GtRoeY2xHjts/FNkA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ffb3c9b700e759be2ef13237c9d8f953b32a1e46",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+# Root flake for SKey.
+#
+# Flakes are only discovered at the repository root, so this file re-exports
+# the real packaging (package derivation + NixOS module) that lives in
+# packaging/nixos/flake.nix.  Without this, `inputs.skey.url =
+# "github:collyn/skey"` would fail with "does not provide attribute flake.nix".
+#
+# Usage in your own flake:
+#   inputs.skey.url = "github:collyn/skey";
+#
+#   outputs = { nixpkgs, skey, ... }: {
+#     nixosConfigurations.hostname = nixpkgs.lib.nixosSystem {
+#       modules = [
+#         skey.nixosModules.default
+#         {
+#           i18n.inputMethod = {
+#             enable = true;
+#             type = "fcitx5";
+#             fcitx5.addons = [ skey.packages.${pkgs.system}.fcitx5-skey ];
+#           };
+#           services.fcitx5-skey = {
+#             enable = true;
+#             users = [ "yourusername" ];
+#           };
+#         }
+#       ];
+#     };
+#   };
+#
+# See packaging/nixos/README.md for details.
+{
+  description = "SKey — Vietnamese input method for Fcitx5";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    (import ./packaging/nixos/flake.nix).outputs { inherit self nixpkgs; };
+}

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -7,7 +7,7 @@ pkgrel=1
 pkgdesc="Vietnamese SKey input method addon for Fcitx5 (skey-engine)"
 arch=('x86_64')
 url="https://github.com/collyn/skey"
-license=('MIT')
+license=('GPL-3.0-or-later')
 depends=('fcitx5' 'hicolor-icon-theme' 'qt6-base' 'qt6-svg' 'systemd' 'acl')
 makedepends=('cmake' 'extra-cmake-modules' 'gettext' 'dbus' 'rust' 'gcc' 'libxcb' 'librsvg')
 # source is the git checkout itself — CI populates src/ before invoking makepkg -e

--- a/packaging/fcitx5-skey.spec
+++ b/packaging/fcitx5-skey.spec
@@ -13,7 +13,7 @@ Version:        0.5.6
 Release:        1%{?dist}
 Summary:        Vietnamese SKey input method addon for Fcitx5
 
-License:        MIT
+License:        GPL-3.0-or-later
 URL:            https://github.com/collyn/skey
 # Source is the git checkout; CI populates ~/rpmbuild/SOURCES or builds from checkout
 Source0:        fcitx5-skey-%{version}.tar.gz

--- a/packaging/nixos/README.md
+++ b/packaging/nixos/README.md
@@ -18,11 +18,14 @@
     nixosConfigurations.hostname = nixpkgs.lib.nixosSystem {
       modules = [
         skey.nixosModules.default
-        {
+        { config, ... }: {
           i18n.inputMethod = {
             enable = true;
             type = "fcitx5";
-            fcitx5.addons = [ skey.packages.x86_64-linux.fcitx5-skey ];
+            # Tham chiếu qua module (không phải pkgs trực tiếp) để
+            # services.fcitx5-skey.devVersion (kênh Dev) áp dụng cho cả
+            # engine addon lẫn uinput server.
+            fcitx5.addons = [ config.services.fcitx5-skey.package ];
           };
           services.fcitx5-skey = {
             enable = true;
@@ -62,6 +65,41 @@ Các biến môi trường (`GTK_IM_MODULE`, `QT_IM_MODULE`, …) do module
 
 Sau `nixos-rebuild switch`, chạy `fcitx5 -r -d` (hoặc logout/login), rồi
 bật SKey trong `fcitx5-configtool`.
+
+## Kênh Dev
+
+Settings GUI (tab Thông tin → Kênh cập nhật: Thử nghiệm) hoạt động trên
+NixOS bằng cách:
+
+- pin flake input vào đúng tag prerelease
+  (`github:collyn/skey/v0.7.7-dev.3`) qua `nix flake update --override-input`
+  — source build ra **y hệt** source của dev package trên các distro khác
+- ghi `services.fcitx5-skey.devVersion = "0.7.7-dev.3";` vào
+  `configuration.nix` (kèm marker comment do GUI quản lý) — build mang
+  version string dev + counter (`SKEY_DEV_BUILD`) nên updater nhận diện
+  đúng bản dev, không lặp lại offer cùng tag
+
+Quay lại kênh Stable, GUI xóa block devVersion và reset input về
+`github:collyn/skey`.
+
+Thủ công tương đương:
+
+```bash
+# Bật dev (thay tag bằng dev prerelease mới nhất):
+# thêm vào configuration.nix:
+#   services.fcitx5-skey.devVersion = "0.7.7-dev.3";
+sudo nix flake lock --override-input skey github:collyn/skey/v0.7.7-dev.3
+sudo nixos-rebuild switch --flake /etc/nixos
+
+# Về stable:
+# xóa dòng devVersion khỏi configuration.nix
+sudo nix flake lock --override-input skey github:collyn/skey
+sudo nixos-rebuild switch --flake /etc/nixos
+```
+
+Điều kiện để dev channel áp dụng đúng: addon phải tham chiếu
+`config.services.fcitx5-skey.package` (như ví dụ trên) — nếu dùng
+`pkgs.fcitx5-skey` trực tiếp, engine addon vẫn là bản stable.
 
 ## Đóng gói riêng (không dùng flake)
 

--- a/packaging/nixos/README.md
+++ b/packaging/nixos/README.md
@@ -2,6 +2,7 @@
 
 | File | Nội dung |
 |---|---|
+| `../../flake.nix` | Flake ở repo root, re-export thư mục này (flakes chỉ được phát hiện ở root) |
 | `flake.nix` | Package `fcitx5-skey` + NixOS module |
 | `default.nix` | Package derivation (dùng được không cần flake) |
 | `module.nix` | `services.fcitx5-skey` — uinput server, polkit rule |
@@ -41,9 +42,16 @@ và `XDG_DATA_DIRS` trỏ vào package — đây là cách fcitx5 tìm thấy `s
 Module `services.fcitx5-skey` xử lý những việc mà trên Fedora/Debian do
 `%post` của RPM/DEB làm:
 
-- `hardware.uinput.enable = true` — load module + udev rule cho `/dev/uinput`
+- `hardware.uinput.enable = true` — load module + tạo group `uinput` với
+  udev rule `MODE="0660" GROUP="uinput"` cho `/dev/uinput`
+- Tạo system user `skey_uinput` và thêm vào group `uinput` — đây là cách
+  NixOS cấp quyền mở `/dev/uinput` cho server (udev rule trong package gọi
+  `/usr/bin/setfacl`, không dùng được trên NixOS — xem Ghi chú kỹ thuật)
 - `systemd.packages` — nạp unit template `fcitx5-skey-uinput-server@.service`
-  từ package và enable một instance cho mỗi user trong `users`
+  từ package và enable một instance cho mỗi user trong `users`; đồng thời
+  override `ExecStartPre`/`ExecStartPost` của unit bằng store path của
+  `setfacl` (template gốc gọi `/usr/bin/setfacl` và
+  `/usr/bin/systemd-sysusers` — không tồn tại trên NixOS)
 - Polkit rule (qua `security.polkit.extraConfig` — trên NixOS
   `/etc/polkit-1/rules.d` là file được generate, không sửa trực tiếp) để
   user restart instance của mình không cần mật khẩu
@@ -63,6 +71,11 @@ pkgs.callPackage (builtins.fetchTarball "https://github.com/collyn/skey/archive/
 
 ## Ghi chú kỹ thuật
 
+- **`nixosModules.default` là wrapper module**: overlay `fcitx5-skey` vào
+  pkgs (để `services.fcitx5-skey.package` mặc định resolve được — package
+  nằm trong flake chứ không phải nixpkgs) rồi mới import `module.nix`.
+  Nếu dùng `module.nix` trực tiếp (không qua flake), phải tự overlay
+  hoặc set `services.fcitx5-skey.package` thủ công.
 - **skey-engine (Rust)** được build bằng `buildRustPackage` riêng vì bước
   cargo trong CMake cần network (bị cấm trong sandbox nix). CMake được
   truyền `-DSKEY_ENGINE_PREBUILT_LIB` để bỏ qua bước cargo và
@@ -70,10 +83,31 @@ pkgs.callPackage (builtins.fetchTarball "https://github.com/collyn/skey/archive/
   `Cargo.lock` của skey-engine nên không cần `cargoHash`.
 - **Path distro-specific** (`/lib/systemd/system`, `/etc/polkit-1/rules.d`,
   `/etc/profile.d`) được override qua cache vars `SKEY_SYSTEMD_UNIT_DIR`,
-  `SKEY_POLKIT_RULES_DIR`, `SKEY_PROFILE_D_DIR` để trỏ vào `$out` — mặc định
-  giữ nguyên như cũ cho Fedora/Debian/Arch.
+  `SKEY_POLKIT_RULES_DIR`, `SKEY_UDEV_RULES_DIR`, `SKEY_SYSUSERS_DIR`,
+  `SKEY_PROFILE_D_DIR` (định nghĩa trong `data/CMakeLists.txt`) để trỏ vào
+  `$out` — mặc định giữ nguyên như cũ cho Fedora/Debian/Arch.
+- **Udev rule của package KHÔNG ship qua `services.udev.packages`**:
+  nixpkgs có guard quét udev rules còn reference `/usr/bin` và fail build
+  (`exit 1`) — rule `99-skey-uinput.rules` gọi `/usr/bin/setfacl` nên sẽ
+  dính guard. Thay vào đó module thêm `skey_uinput` vào group `uinput`
+  (do `hardware.uinput.enable` tạo, 0660 trên `/dev/uinput`) — tương đương
+  về quyền hạn và hoàn toàn declarative. `ExecStartPre`/`ExecStartPost`
+  của unit được override bằng `${pkgs.acl}/bin/setfacl` (store path) để
+  giữ ACL belt-and-braces cho device node và ACL per-user trên
+  `/run/skey-uinput-<user>`.
 - **Icon**: code có fallback `FCITX_SKEY_ICON_PATH` compile-time trỏ vào
   `$out/share/icons/...` nên tray icon hoạt động dù `/usr/share/icons`
   không tồn tại trên NixOS.
 - `qt6.qtwayland` được wrap vào settings GUI (wrapQtAppsHook) để chạy được
   trên Wayland; `qt6.qtsvg` để QIcon load SVG.
+
+## Kiểm tra không cần máy NixOS
+
+Trên máy không có nix, có thể validate syntax + eval bằng container:
+
+```sh
+docker run --rm -v "$PWD":/src -w /src nixos/nix \
+  nix-instantiate --parse packaging/nixos/default.nix packaging/nixos/module.nix flake.nix
+docker run --rm -v "$PWD":/src -w /src nixos/nix \
+  nix build .#fcitx5-skey --no-link
+```

--- a/packaging/nixos/default.nix
+++ b/packaging/nixos/default.nix
@@ -27,9 +27,26 @@
     url = "https://github.com/collyn/skey-engine/archive/refs/tags/v0.1.23.tar.gz";
     sha256 = "sha256-wtbL+cjr28DKTbNKoQiQwQyCKiSIs08/ghG0uw4l/08=";
   },
+  # Dev channel: set to the dev prerelease version (e.g. "0.7.7-dev.3") to
+  # build the package with that version string and the dev-build counter
+  # (SKEY_APP_VERSION / SKEY_DEV_BUILD), so the updater recognizes the
+  # build instead of re-offering the same dev tag forever.  null = stable.
+  devVersion ? null,
 }:
 
 let
+  # Version parsed from the top-level CMakeLists.txt (mirrors PKGBUILD's
+  # pkgver()) so a release bump never has to touch two files.  project()
+  # VERSION stays purely numeric, so the derived string is always a valid
+  # Nix version.
+  stableVersion = let
+    cm = builtins.replaceStrings [ "\n" ] [ " " ]
+      (builtins.readFile ../../CMakeLists.txt);
+    m = builtins.match ".*project\\(fcitx5-skey VERSION ([0-9.]+)\\).*" cm;
+  in if m == null
+     then throw "fcitx5-skey: cannot parse version from ../../CMakeLists.txt"
+     else builtins.head m;
+
   skeyEngine = rustPlatform.buildRustPackage {
     pname = "skey-engine";
     version = "0.1.23";
@@ -57,7 +74,7 @@ let
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "fcitx5-skey";
-  version = "0.7.7";
+  version = if devVersion == null then stableVersion else devVersion;
 
   src = ../..;
 
@@ -103,6 +120,12 @@ stdenv.mkDerivation (finalAttrs: {
     "-DSKEY_UDEV_RULES_DIR=${placeholder "out"}/lib/udev/rules.d"
     "-DSKEY_SYSUSERS_DIR=${placeholder "out"}/lib/sysusers.d"
     "-DSKEY_PROFILE_D_DIR=${placeholder "out"}/etc/profile.d"
+  ] ++ lib.optionals (devVersion != null) [
+    # Dev channel: make the GUI/updater report the dev prerelease version
+    # (the "-dev.N" suffix is what the updater parses to compare counters)
+    # and mark this as a dev build.  The counter is the last component.
+    "-DSKEY_APP_VERSION=${devVersion}"
+    "-DSKEY_DEV_BUILD=${toString (lib.toInt (lib.last (lib.splitString "." devVersion)))}"
   ];
 
   meta = with lib; {

--- a/packaging/nixos/default.nix
+++ b/packaging/nixos/default.nix
@@ -9,61 +9,86 @@
   stdenv,
   cmake,
   pkg-config,
-  extra-cmake-modules,
+  kdePackages, # extra-cmake-modules (top-level alias removed after KDE Gear 5 EOL)
   gettext,
   librsvg, # rsvg-convert for PNG tray icons
   dbus,
-  xorg, # libxcb (X11 WM_CLASS detection)
+  libxcb, # X11 WM_CLASS detection
   fcitx5,
-  qt6, # settings GUI (qtbase/qtwayland/qtsvg)
-  wrapQtAppsHook,
+  qt6, # settings GUI (qtbase/qtwayland/qtsvg) + wrapQtAppsHook
   rustPlatform,
   # Source of https://github.com/collyn/skey-engine.  Overridable so a
   # caller can pass its own fetchFromGitHub result (pinned with a hash).
+  # Keep in sync with SKEY_ENGINE_VERSION in the top-level CMakeLists.txt.
+  # The sha256 keeps the fetch legal under pure evaluation (flakes); it
+  # must be updated whenever the tag changes (nix store prefetch-file
+  # --unpack <tarball-url>).
   skeyEngineSrc ? builtins.fetchTarball {
-    url = "https://github.com/collyn/skey-engine/archive/refs/tags/v0.1.20.tar.gz";
+    url = "https://github.com/collyn/skey-engine/archive/refs/tags/v0.1.23.tar.gz";
+    sha256 = "sha256-wtbL+cjr28DKTbNKoQiQwQyCKiSIs08/ghG0uw4l/08=";
   },
 }:
 
 let
   skeyEngine = rustPlatform.buildRustPackage {
     pname = "skey-engine";
-    version = "0.1.20";
+    version = "0.1.23";
     src = skeyEngineSrc;
     # Cargo.lock carries the per-crate checksums, so no cargoHash is needed.
     cargoLock.lockFile = "${skeyEngineSrc}/Cargo.lock";
     doCheck = false;
     installPhase = ''
       runHook preInstall
-      install -Dm644 target/release/libskey_engine.a "$out/lib/libskey_engine.a"
+      # cargoBuildHook passes --target <rustcTarget>, so artifacts land in
+      # target/<triple>/release/, not target/release/.
+      install -Dm644 target/${stdenv.hostPlatform.rust.rustcTarget}/release/libskey_engine.a \
+        "$out/lib/libskey_engine.a"
       install -Dm644 skey_engine.h "$out/include/skey_engine.h"
       runHook postInstall
     '';
+
+    meta = with lib; {
+      # skey-engine repo is GPL-3.0-or-later too (its LICENSE has the same
+      # "at your option, any later version" grant).
+      license = licenses.gpl3Plus;
+      platforms = platforms.linux;
+    };
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "fcitx5-skey";
-  version = "0.6.4";
+  version = "0.7.7";
 
   src = ../..;
+
+  # The repo ships in-tree build dirs (build/, build-dev/, CMakeFiles/,
+  # Testing/, compile_commands.json) whose CMakeCache.txt records the
+  # original absolute source path.  Nix's cmake configure step would reuse
+  # that stale cache and die with "does not match the source".  They are
+  # local artifacts, never needed for a clean build.
+  preConfigure = ''
+    rm -rf build build-dev CMakeFiles Testing compile_commands.json
+  '';
 
   nativeBuildInputs = [
     cmake
     pkg-config
-    extra-cmake-modules
+    kdePackages.extra-cmake-modules
     gettext
     librsvg
-    wrapQtAppsHook
+    qt6.wrapQtAppsHook
   ];
 
   buildInputs = [
     fcitx5
     dbus
-    xorg.libxcb
+    libxcb
     qt6.qtbase
     qt6.qtwayland # runtime platform plugin for the settings GUI on Wayland
     qt6.qtsvg # QIcon SVG loading at runtime
-    acl # setfacl in the uinput server unit's ExecStartPre
+    # No `acl` here: setfacl is only referenced as text inside the unit
+    # and udev rule files, never invoked at build time.  The NixOS module
+    # uses pkgs.acl directly for its ExecStartPre/ExecStartPost overrides.
   ];
 
   cmakeFlags = [
@@ -83,7 +108,8 @@ stdenv.mkDerivation (finalAttrs: {
   meta = with lib; {
     description = "SKey Vietnamese input method engine addon for Fcitx5";
     homepage = "https://github.com/collyn/skey";
-    license = licenses.mit;
+    # Root LICENSE: GPL-3.0-or-later ("at your option, any later version").
+    license = licenses.gpl3Plus;
     maintainers = [ ];
     platforms = platforms.linux;
   };

--- a/packaging/nixos/flake.nix
+++ b/packaging/nixos/flake.nix
@@ -1,9 +1,11 @@
 # fcitx5-skey flake — package + NixOS module.
 #
-# Usage:
+# Flakes are only discovered at the repository root; the flake.nix at the
+# repo root re-exports this file so that a plain URL works:
 #   inputs.skey.url = "github:collyn/skey";
 #   # or, for a local checkout:
 #   # inputs.skey.url = "path:/path/to/skey";
+# (For this subdirectory directly, use "github:collyn/skey?dir=packaging/nixos".)
 #
 #   i18n.inputMethod = {
 #     enable = true;
@@ -34,7 +36,19 @@
       });
 
       nixosModules = {
-        fcitx5-skey = import ./module.nix;
+        # Wrapper module: overlays the package into pkgs so that
+        # module.nix's `lib.mkPackageOption pkgs "fcitx5-skey"` resolves
+        # (the package lives in this flake, not in nixpkgs), then imports
+        # the module itself.  Consumers of skey.nixosModules.default get
+        # pkgs.fcitx5-skey for free.
+        fcitx5-skey = {
+          nixpkgs.overlays = [
+            (final: prev: {
+              fcitx5-skey = self.packages.${final.stdenv.hostPlatform.system}.fcitx5-skey;
+            })
+          ];
+          imports = [ ./module.nix ];
+        };
         default = self.nixosModules.fcitx5-skey;
       };
     };

--- a/packaging/nixos/module.nix
+++ b/packaging/nixos/module.nix
@@ -38,6 +38,19 @@ in
 
     package = lib.mkPackageOption pkgs "fcitx5-skey" { };
 
+    devVersion = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "0.7.7-dev.3";
+      description = ''
+        Dev channel: set to the dev prerelease version to build the package
+        with that version string and dev-build counter.  The settings GUI
+        writes this option (with marker comments) when the dev update
+        channel is selected, together with pinning the flake input to the
+        matching dev tag — keep `null` for stable releases.
+      '';
+    };
+
     users = lib.mkOption {
       type = lib.types.listOf lib.types.str;
       default = [ ];
@@ -53,6 +66,13 @@ in
 
   config = lib.mkIf cfg.enable {
     hardware.uinput.enable = true;
+
+    # Dev channel: rebuild the package with the dev version string + counter
+    # so the settings GUI / updater recognizes the build (otherwise the same
+    # dev tag would be re-offered forever).  Overrides the mkPackageOption
+    # default; stable (null) keeps plain pkgs.fcitx5-skey.
+    services.fcitx5-skey.package = lib.mkIf (cfg.devVersion != null)
+      (pkgs.fcitx5-skey.override { inherit (cfg) devVersion; });
 
     environment.systemPackages = [ cfg.package ];
 

--- a/packaging/nixos/module.nix
+++ b/packaging/nixos/module.nix
@@ -3,8 +3,17 @@
 # What it does (the pieces that the RPM/DEB %post scripts handle manually
 # on other distros):
 #   * loads the uinput kernel module (hardware.uinput.enable)
+#   * creates the dedicated skey_uinput system user and grants it
+#     /dev/uinput access via the "uinput" group that hardware.uinput
+#     already declares (0660 root:uinput).  The package's udev ACL rule
+#     cannot be used on NixOS: it calls /usr/bin/setfacl, and nixpkgs'
+#     udev rule processing rejects rules that reference /usr/bin programs
+#     (there is no /usr/bin on NixOS anyway).
 #   * makes the systemd template unit from the package known to systemd
 #     (systemd.packages) and enables one uinput-server instance per user
+#   * overrides the unit's setfacl ExecStartPre/ExecStartPost with nix
+#     store paths (the template's /usr/bin/systemd-sysusers and
+#     /usr/bin/setfacl don't exist on NixOS)
 #   * adds the polkit rule so each user can restart their own instance
 #     without a password prompt (the settings GUI and skey-setup call
 #     `systemctl try-restart fcitx5-skey-uinput-server@$USER.service`)
@@ -47,19 +56,22 @@ in
 
     environment.systemPackages = [ cfg.package ];
 
-    # Dedicated system user the uinput server runs as.  The udev rule
-    # (shipped in the package) grants it an rw ACL on /dev/uinput — never
-    # group "input", which would let it read every /dev/input/event*
-    # device.  No user needs group membership: the socket is chmod 0666
-    # in a 0771 RuntimeDirectory; SO_PEERCRED + /proc/pid/exe checks at
-    # accept time are the real authorization.
+    # Dedicated system user the uinput server runs as.  On other distros
+    # the package's udev rule grants it an rw ACL on /dev/uinput; on NixOS
+    # that rule is unusable (see header), so the user is put into the
+    # "uinput" group that hardware.uinput.enable declares — the device is
+    # 0660 root:uinput.  That grants exactly one privilege: opening
+    # /dev/uinput.  Deliberately NOT group "input", which would let the
+    # server read every /dev/input/event* device (a keylogging surface).
+    # No real user needs group membership: the socket dir is 0700 with a
+    # per-user named ACL (ExecStartPost override below), and accept-time
+    # checks (SO_PEERCRED + /proc/pid/exe) are the real authorization.
     users.users.skey_uinput = {
       isSystemUser = true;
       group = "skey_uinput";
+      extraGroups = [ "uinput" ];
     };
     users.groups.skey_uinput = { };
-
-    services.udev.packages = [ cfg.package ];
 
     # Load the template unit shipped in the package
     # ($out/lib/systemd/system/fcitx5-skey-uinput-server@.service).
@@ -67,17 +79,29 @@ in
 
     # Enable one instance per user.  NixOS treats `...@<user>` as a
     # literal instance unit, which systemd merges over the template above.
+    #
+    # The template's ExecStartPre/ExecStartPost call /usr/bin/systemd-sysusers
+    # and /usr/bin/setfacl — neither exists on NixOS — so override them
+    # with store paths.  sysusers is unnecessary here (the user above is
+    # declarative); the /dev/uinput ACL is a belt-and-braces fallback for
+    # the group-based access; the ExecStartPost ACL is what lets <user>
+    # traverse the 0700 runtime directory to reach the fs socket (without
+    # it clients silently fall back to the legacy abstract socket).
     systemd.services = lib.listToAttrs (
       map (user:
         lib.nameValuePair "fcitx5-skey-uinput-server@${user}" {
           wantedBy = [ "multi-user.target" ];
+          serviceConfig = {
+            ExecStartPre = [
+              "-+${pkgs.acl}/bin/setfacl -m u:skey_uinput:rw /dev/uinput"
+            ];
+            ExecStartPost = [
+              "-+${pkgs.acl}/bin/setfacl -m u:${user}:x /run/skey-uinput-${user}"
+            ];
+          };
         }
       ) cfg.users
     );
-
-    # No group membership needed for users: the server socket is chmod
-    # 0666 in a 0771 RuntimeDirectory, and authorization happens at
-    # accept time (SO_PEERCRED + /proc/pid/exe).
 
     # Polkit rule from the package: each user may (re)start only their
     # own fcitx5-skey-uinput-server@<user>.service without admin auth.

--- a/scripts/publish-all.sh
+++ b/scripts/publish-all.sh
@@ -330,7 +330,9 @@ services.fcitx5-skey = {
 i18n.inputMethod = {
   enable = true;
   type = "fcitx5";
-  fcitx5.addons = [ pkgs.fcitx5-skey ];
+  # Reference the module's package (not pkgs directly) so the dev channel
+  # (services.fcitx5-skey.devVersion) applies to the addon too.
+  fcitx5.addons = [ config.services.fcitx5-skey.package ];
 };
 # ── end fcitx5-skey ──
 EOF

--- a/scripts/publish-all.sh
+++ b/scripts/publish-all.sh
@@ -226,6 +226,138 @@ sed -i "s|GHP_URL|${GITHUB_PAGES_URL}|g" install-arch.sh
 sed -i "s|GPG_EMAIL|${GPG_KEY_EMAIL}|g" install-arch.sh
 chmod +x install-arch.sh
 
+# install-nixos.sh (NixOS — wires the flake input + module, no repo config)
+cat > install-nixos.sh << 'INSTEOF'
+#!/bin/bash
+# fcitx5-skey NixOS installer — wires the skey flake input + module into
+# your system configuration, then tells you to rebuild.
+#
+# Requirements: NixOS with a flake configuration (/etc/nixos/flake.nix).
+# Idempotent: re-running is a no-op.
+set -e
+
+FLAKE=/etc/nixos/flake.nix
+CONFIG=/etc/nixos/configuration.nix
+USER_NAME="${SUDO_USER:-$USER}"
+MISSING=0
+
+if [ ! -f /etc/NIXOS ] && ! grep -q '^ID=nixos$' /etc/os-release 2>/dev/null; then
+    echo "✗ This script is for NixOS only."
+    exit 1
+fi
+if [ ! -f "$FLAKE" ]; then
+    echo "✗ $FLAKE not found — a flake configuration is required."
+    echo "  See https://github.com/collyn/skey/blob/main/packaging/nixos/README.md"
+    exit 1
+fi
+if [ ! -w "$FLAKE" ]; then
+    echo "✗ $FLAKE is not writable — run via: curl -fsSL https://collyn.github.io/skey/install-nixos.sh | sudo bash"
+    exit 1
+fi
+
+# 1) flake input: skey.url = "github:collyn/skey";
+if grep -q 'skey\.url' "$FLAKE"; then
+    echo "✓ skey input already present in $FLAKE"
+else
+    if grep -q '^[[:space:]]*inputs[[:space:]]*=[[:space:]]*{[[:space:]]*$' "$FLAKE"; then
+        sed -i '/^[[:space:]]*inputs[[:space:]]*=[[:space:]]*{[[:space:]]*$/a\    skey.url = "github:collyn/skey";' "$FLAKE"
+        echo "✓ Added skey input to $FLAKE"
+    else
+        echo "⚠ Could not find 'inputs = {' in $FLAKE — add manually:"
+        echo '    skey.url = "github:collyn/skey";'
+        MISSING=1
+    fi
+fi
+
+# 2) outputs signature: add `skey` next to `nixpkgs`
+if grep -q 'outputs[[:space:]]*=[[:space:]]*{[^}]*skey,' "$FLAKE"; then
+    echo "✓ skey already in outputs"
+else
+    sed -i -E 's|(outputs[[:space:]]*=[[:space:]]*\{[^}]*nixpkgs,)([^}]*\})|\1 skey,\2|' "$FLAKE"
+    if grep -q 'outputs[[:space:]]*=[[:space:]]*{[^}]*skey,' "$FLAKE"; then
+        echo "✓ Added skey to the outputs function signature"
+    else
+        echo "⚠ Could not update the outputs signature — add 'skey' next to 'nixpkgs' manually."
+        MISSING=1
+    fi
+fi
+
+# 3) module import: skey.nixosModules.default in every nixosConfiguration
+if grep -q 'skey\.nixosModules\.default' "$FLAKE"; then
+    echo "✓ skey module already imported"
+else
+    if grep -q '^[[:space:]]*modules[[:space:]]*=[[:space:]]*\[' "$FLAKE"; then
+        awk '
+            /^[[:space:]]*modules[[:space:]]*=[[:space:]]*\[.*\];[[:space:]]*$/ {
+                # one-line list: split after "[" and insert the module first
+                sub(/\[[[:space:]]*/, "[\n        skey.nixosModules.default\n        ")
+                print
+                next
+            }
+            {
+                print
+            }
+            /^[[:space:]]*modules[[:space:]]*=[[:space:]]*\[/ {
+                # multi-line list: insert right after the opening bracket line
+                print "        skey.nixosModules.default"
+            }
+        ' "$FLAKE" > "$FLAKE.tmp" && mv "$FLAKE.tmp" "$FLAKE"
+        echo "✓ Imported skey.nixosModules.default in $FLAKE"
+    else
+        echo "⚠ No 'modules = [' found in $FLAKE — add 'skey.nixosModules.default' to your nixosConfigurations modules list manually."
+        MISSING=1
+    fi
+fi
+
+# 4) configuration.nix: uinput server + fcitx5 addon
+if grep -q 'services\.fcitx5-skey' "$CONFIG"; then
+    echo "✓ $CONFIG already configures services.fcitx5-skey"
+else
+    if grep -q 'i18n\.inputMethod' "$CONFIG"; then
+        echo "⚠ $CONFIG already configures i18n.inputMethod — merge the fcitx5 addon block manually to avoid option conflicts."
+        MISSING=1
+    fi
+    if [ "$USER_NAME" = "root" ]; then
+        echo "⚠ Could not determine your user (script ran as root) — edit users in $CONFIG after the rebuild fails."
+    fi
+    cat >> "$CONFIG" <<EOF
+
+# ── fcitx5-skey (added by install script) ──
+services.fcitx5-skey = {
+  enable = true;
+  users = [ "$USER_NAME" ];
+};
+i18n.inputMethod = {
+  enable = true;
+  type = "fcitx5";
+  fcitx5.addons = [ pkgs.fcitx5-skey ];
+};
+# ── end fcitx5-skey ──
+EOF
+    echo "✓ Added skey config to $CONFIG (uinput server for user: $USER_NAME)"
+fi
+
+# 5) lock the new input so the first rebuild does not fail on eval
+if command -v nix >/dev/null 2>&1; then
+    if (cd /etc/nixos && nix --extra-experimental-features 'nix-command flakes' flake update skey); then
+        echo "✓ Locked skey input in flake.lock"
+    else
+        echo "⚠ Could not lock the skey input now — the first nixos-rebuild will fetch it automatically."
+    fi
+fi
+
+if [ "$MISSING" = "1" ]; then
+    echo "⚠ Some steps need manual attention — see messages above."
+fi
+echo ""
+echo "✓ Done. Rebuild your system:"
+echo "  sudo nixos-rebuild switch --flake /etc/nixos"
+echo ""
+echo "  Restart fcitx5: fcitx5 -r -d  (or logout/login)"
+echo "  Updates: open fcitx5-skey-settings → Check Update"
+INSTEOF
+chmod +x install-nixos.sh
+
 # ── Commit and push ──────────────────────────────────────────────────
 git checkout gh-pages 2>/dev/null || true
 git add -A
@@ -249,3 +381,4 @@ echo "  APT:     curl -fsSL ${GITHUB_PAGES_URL}/install.sh | sudo bash"
 echo "  Fedora:  curl -fsSL ${GITHUB_PAGES_URL}/install-fedora.sh | sudo bash"
 echo "  openSUSE: curl -fsSL ${GITHUB_PAGES_URL}/install-opensuse.sh | sudo bash"
 echo "  Arch:    curl -fsSL ${GITHUB_PAGES_URL}/install-arch.sh | sudo bash"
+echo "  NixOS:   curl -fsSL ${GITHUB_PAGES_URL}/install-nixos.sh | sudo bash"

--- a/src/settings/appearance_tab.cpp
+++ b/src/settings/appearance_tab.cpp
@@ -72,24 +72,30 @@ QIcon makeRoundedIcon(const QString &iconPath, int size,
     QIcon icon(iconPath);
     if (icon.isNull()) return {};
 
+    // QIcon::pixmap() treats `size` as device-independent and returns a
+    // pixmap already scaled by the app's devicePixelRatio.  Start `rounded`
+    // from src so both share physical size and dpr — the draw below is then
+    // identity.  The old code passed a pre-multiplied size plus an explicit
+    // source rect, double-scaling the icon so it overflowed the tile at
+    // fractional scaling (e.g. 125%).
     QPixmap src = icon.pixmap(size, size);
-    QPixmap rounded(size, size);
+    QPixmap rounded = src;
     rounded.fill(Qt::transparent);
     QPainter p(&rounded);
     p.setRenderHint(QPainter::Antialiasing, true);
 
-    // Clip to rounded rect
+    const QSizeF logical = rounded.deviceIndependentSize();
     QPainterPath pp;
-    pp.addRoundedRect(QRectF(0, 0, size, size), kTileRadius - 2, kTileRadius - 2);
+    pp.addRoundedRect(QRectF(QPointF(0, 0), logical), kTileRadius - 2, kTileRadius - 2);
     p.setClipPath(pp);
 
     // Solid background fill
     if (bgColor.alpha() > 0) {
-        p.fillRect(QRectF(0, 0, size, size), bgColor);
+        p.fillRect(QRectF(QPointF(0, 0), logical), bgColor);
     }
 
     // Icon on top
-    p.drawPixmap(QRectF(0, 0, size, size), src, QRectF(0, 0, size, size));
+    p.drawPixmap(0, 0, src);
     p.end();
     return QIcon(rounded);
 }

--- a/src/settings/config_io.cpp
+++ b/src/settings/config_io.cpp
@@ -542,10 +542,14 @@ bool removeCustomIcon(const std::string &filename) {
 std::string effectiveIconPath(const SKeyConfig &cfg) {
     skey::IconSearchPaths paths;
     paths.userDataDir = userDataDir();
-    // PNG-first for Qt (renders natively without QtSvg plugin)
+    // SVG first: renders crisp at any scale/DPR, while the 128px PNG gets
+    // visibly soft or pixelated at fractional HiDPI scaling.  Both callers
+    // (info tab + settings window icon) fall back to the PNG when QIcon
+    // returns null — i.e. exactly when the QtSvg plugin is missing — so
+    // environments without libqt6svg stay covered.
     paths.systemDirs = {
-        "/usr/share/icons/hicolor/128x128/apps",
         "/usr/share/icons/hicolor/scalable/apps",
+        "/usr/share/icons/hicolor/128x128/apps",
         "/usr/share/pixmaps",
     };
     paths.fallback = "/usr/share/icons/hicolor/128x128/apps/fcitx-skey.png";

--- a/src/settings/info_tab.cpp
+++ b/src/settings/info_tab.cpp
@@ -78,7 +78,12 @@ void InfoTab::setupUI() {
     QPainterPath path;
     path.addRoundedRect(QRectF(0, 0, 80, 80), 12, 12);
     painter.setClipPath(path);
-    painter.drawPixmap(QRectF(0, 0, 80, 80), src, QRectF(0, 0, 80, 80));
+    // Draw the whole source at its logical size.  An explicit sourceRect is
+    // interpreted in device pixels once the pixmap carries a
+    // devicePixelRatio, so at fractional scaling (e.g. 125%) the old
+    // QRectF(0,0,80,80) source rect cropped and zoomed the icon until it
+    // overflowed the rounded tile.
+    painter.drawPixmap(0, 0, src);
     painter.end();
     iconLabel->setPixmap(rounded);
   } else {

--- a/src/settings/info_tab.cpp
+++ b/src/settings/info_tab.cpp
@@ -6,6 +6,7 @@
 #include <QComboBox>
 #include <QDateTime>
 #include <QDir>
+#include <QFile>
 #include <QFileDialog>
 #include <QFrame>
 #include <QHBoxLayout>
@@ -17,6 +18,7 @@
 #include <QProgressBar>
 #include <QPushButton>
 #include <QSignalBlocker>
+#include <QStandardPaths>
 #include <QTemporaryDir>
 #include <QTimer>
 #include <QUrl>
@@ -45,6 +47,8 @@ InfoTab::InfoTab(QWidget *parent) : QWidget(parent) {
   connect(updater_, &Updater::installStarted, this, &InfoTab::onInstallStarted);
   connect(updater_, &Updater::installFinished, this,
           &InfoTab::onInstallFinished);
+  connect(updater_, &Updater::nixosManualUpdateRequired, this,
+          &InfoTab::onNixosManualUpdateRequired);
 
   setupUI();
 }
@@ -297,10 +301,17 @@ void InfoTab::onUpdateAvailable(const QString &newVersion,
   }
 
   if (downloadUrl.isEmpty()) {
-    msg += QString::fromUtf8("\n\nKhông tìm thấy file cài đặt phù hợp. "
-                             "Vui lòng tải thủ công từ GitHub.");
-    QMessageBox::information(this, QString::fromUtf8("Có bản cập nhật"), msg);
-    return;
+    if (updater_->distro() == Distro::NixOS) {
+      // No asset expected on NixOS: the update is a system rebuild.
+      msg += QString::fromUtf8(
+          "\n\nBạn đang dùng NixOS: bản cập nhật sẽ được cài qua "
+          "nixos-rebuild (không tải file từ GitHub).");
+    } else {
+      msg += QString::fromUtf8("\n\nKhông tìm thấy file cài đặt phù hợp. "
+                               "Vui lòng tải thủ công từ GitHub.");
+      QMessageBox::information(this, QString::fromUtf8("Có bản cập nhật"), msg);
+      return;
+    }
   }
 
   QMessageBox msgBox(this);
@@ -315,7 +326,22 @@ void InfoTab::onUpdateAvailable(const QString &newVersion,
   if (msgBox.clickedButton() == yesBtn) {
     // User chose "Cập nhật ngay"
     updateBtn_->setEnabled(false);
-    updateBtn_->setText(QString::fromUtf8("Đang tải..."));
+    updateBtn_->setText(QString::fromUtf8("Đang cập nhật..."));
+
+    if (updater_->distro() == Distro::NixOS) {
+      if (!QFile::exists("/etc/nixos/flake.nix")) {
+        showNixosManualInstructions();
+        updateBtn_->setEnabled(true);
+        updateBtn_->setText(QString::fromUtf8("Kiểm tra cập nhật"));
+        return;
+      }
+      progressBar_->setValue(0);
+      progressBar_->setRange(0, 0); // indeterminate — rebuild can take minutes
+      progressBar_->show();
+      updater_->rebuildNixos();
+      return;
+    }
+
     statusLabel_->setText(QString::fromUtf8("Đang tải bản cập nhật..."));
     statusLabel_->setStyleSheet("font-size: 12px; color: #666;");
     statusLabel_->show();
@@ -380,7 +406,15 @@ void InfoTab::onDownloadFailed(const QString &errorMessage) {
 // ── Updater: install slots ──────────────────────────────────────────────
 
 void InfoTab::onInstallStarted() {
-  statusLabel_->setText(QString::fromUtf8("Đang cài đặt... (cần quyền root)"));
+  if (updater_->distro() == Distro::NixOS) {
+    statusLabel_->setText(QString::fromUtf8(
+        "Đang build lại hệ thống bằng nixos-rebuild... (cần quyền root)"));
+    statusLabel_->setStyleSheet("font-size: 12px; color: #666;");
+    statusLabel_->show();
+  } else {
+    statusLabel_->setText(
+        QString::fromUtf8("Đang cài đặt... (cần quyền root)"));
+  }
   progressBar_->setRange(0, 0); // indeterminate
 }
 
@@ -391,6 +425,12 @@ void InfoTab::onInstallFinished(bool success, const QString &message) {
   progressBar_->hide();
 
   if (success) {
+    if (updater_->distro() == Distro::NixOS) {
+      // No package postinst on NixOS: restart fcitx5 + the user's uinput
+      // server (polkit rule in the NixOS module permits it without a
+      // password) so the newly-built skey.so takes effect.
+      restartFcitx5();
+    }
     statusLabel_->setText(QString::fromUtf8("✓ %1").arg(message));
     statusLabel_->setStyleSheet("font-size: 12px; color: green;");
     versionLabel_->setText(
@@ -399,9 +439,15 @@ void InfoTab::onInstallFinished(bool success, const QString &message) {
     // Close and reopen the settings GUI so the user is running
     // the freshly-installed version.  Brief delay lets the user
     // see the success message before the window closes.
-    QTimer::singleShot(1500, this, [this]() {
+    // On NixOS, applicationFilePath() is the OLD store path (alive until
+    // GC); findExecutable resolves through PATH → /run/current-system/sw
+    // → the new generation after the rebuild.
+    QString exe = QStandardPaths::findExecutable("fcitx5-skey-settings");
+    if (exe.isEmpty())
+      exe = QApplication::applicationFilePath();
+    QTimer::singleShot(1500, this, [this, exe]() {
       QWidget *win = window();
-      QProcess::startDetached(QApplication::applicationFilePath(), {});
+      QProcess::startDetached(exe, {});
       if (win)
         win->close();
     });
@@ -410,6 +456,36 @@ void InfoTab::onInstallFinished(bool success, const QString &message) {
     statusLabel_->setStyleSheet("font-size: 12px; color: red;");
   }
   statusLabel_->show();
+}
+
+void InfoTab::onNixosManualUpdateRequired() {
+  updateBtn_->setEnabled(true);
+  updateBtn_->setText(QString::fromUtf8("Kiểm tra cập nhật"));
+  progressBar_->setRange(0, 100);
+  progressBar_->hide();
+  statusLabel_->setText(
+      QString::fromUtf8("Không thể cập nhật tự động — xem hướng dẫn."));
+  statusLabel_->setStyleSheet("font-size: 12px; color: #666;");
+  showNixosManualInstructions();
+}
+
+void InfoTab::showNixosManualInstructions() {
+  const QString instructions = QString::fromUtf8(
+      "Không thể tự động cập nhật SKey trên NixOS.\n\n"
+      "Hệ thống cần dùng flake với input tên là \"skey\".\n"
+      "Thêm vào /etc/nixos/flake.nix:\n\n"
+      "  inputs.skey.url = \"github:collyn/skey\";\n\n"
+      "Rồi chạy (cần quyền root):\n\n"
+      "  cd /etc/nixos\n"
+      "  sudo nix flake update skey\n"
+      "  sudo nixos-rebuild switch --flake /etc/nixos\n"
+      "  fcitx5 -r -d\n\n"
+      "Xem chi tiết: https://github.com/collyn/skey/blob/main/"
+      "packaging/nixos/README.md");
+
+  QMessageBox::information(this,
+                           QString::fromUtf8("Cần cập nhật thủ công"),
+                           instructions);
 }
 
 // ── Backup / Restore ────────────────────────────────────────────────────

--- a/src/settings/info_tab.cpp
+++ b/src/settings/info_tab.cpp
@@ -65,24 +65,22 @@ void InfoTab::setupUI() {
   if (icon.isNull())
     icon = QIcon("/usr/share/icons/hicolor/128x128/apps/fcitx-skey.png");
   if (!icon.isNull()) {
-    qreal dpr = iconLabel->devicePixelRatioF();
-    int pxSize = static_cast<int>(80 * dpr);
-    QPixmap src = icon.pixmap(pxSize, pxSize);
-    src.setDevicePixelRatio(dpr);
-    // Render with rounded corners via a clipped painter
-    QPixmap rounded(pxSize, pxSize);
-    rounded.setDevicePixelRatio(dpr);
+    // QIcon::pixmap() treats its size argument as device-independent and
+    // returns a pixmap already scaled by the app's devicePixelRatio, so ask
+    // for 80×80 and let Qt do the scaling.  Start `rounded` from src so
+    // both share physical size and dpr — the draw below is then identity.
+    // The old code multiplied by dpr by hand (80 * dpr + an explicit
+    // source rect), double-scaling the icon so it overflowed the rounded
+    // tile at fractional scaling (e.g. 125%).
+    QPixmap src = icon.pixmap(80, 80);
+    QPixmap rounded = src;
     rounded.fill(Qt::transparent);
     QPainter painter(&rounded);
     painter.setRenderHint(QPainter::Antialiasing, true);
     QPainterPath path;
-    path.addRoundedRect(QRectF(0, 0, 80, 80), 12, 12);
+    path.addRoundedRect(QRectF(QPointF(0, 0), rounded.deviceIndependentSize()),
+                        12, 12);
     painter.setClipPath(path);
-    // Draw the whole source at its logical size.  An explicit sourceRect is
-    // interpreted in device pixels once the pixmap carries a
-    // devicePixelRatio, so at fractional scaling (e.g. 125%) the old
-    // QRectF(0,0,80,80) source rect cropped and zoomed the icon until it
-    // overflowed the rounded tile.
     painter.drawPixmap(0, 0, src);
     painter.end();
     iconLabel->setPixmap(rounded);

--- a/src/settings/info_tab.cpp
+++ b/src/settings/info_tab.cpp
@@ -306,6 +306,12 @@ void InfoTab::onUpdateAvailable(const QString &newVersion,
       msg += QString::fromUtf8(
           "\n\nBạn đang dùng NixOS: bản cập nhật sẽ được cài qua "
           "nixos-rebuild (không tải file từ GitHub).");
+      if (updateChannel() == UpdateChannel::Dev) {
+        msg += QString::fromUtf8(
+            "\nBản Dev sẽ pin flake input vào tag v%1 và ghi "
+            "services.fcitx5-skey.devVersion vào configuration.nix.")
+                   .arg(newVersion);
+      }
     } else {
       msg += QString::fromUtf8("\n\nKhông tìm thấy file cài đặt phù hợp. "
                                "Vui lòng tải thủ công từ GitHub.");
@@ -338,7 +344,7 @@ void InfoTab::onUpdateAvailable(const QString &newVersion,
       progressBar_->setValue(0);
       progressBar_->setRange(0, 0); // indeterminate — rebuild can take minutes
       progressBar_->show();
-      updater_->rebuildNixos();
+      updater_->rebuildNixos(pendingVersion_);
       return;
     }
 
@@ -407,8 +413,14 @@ void InfoTab::onDownloadFailed(const QString &errorMessage) {
 
 void InfoTab::onInstallStarted() {
   if (updater_->distro() == Distro::NixOS) {
-    statusLabel_->setText(QString::fromUtf8(
-        "Đang build lại hệ thống bằng nixos-rebuild... (cần quyền root)"));
+    if (updateChannel() == UpdateChannel::Dev) {
+      statusLabel_->setText(QString::fromUtf8(
+          "Đang pin bản Dev và build lại hệ thống bằng nixos-rebuild... "
+          "(cần quyền root)"));
+    } else {
+      statusLabel_->setText(QString::fromUtf8(
+          "Đang build lại hệ thống bằng nixos-rebuild... (cần quyền root)"));
+    }
     statusLabel_->setStyleSheet("font-size: 12px; color: #666;");
     statusLabel_->show();
   } else {
@@ -470,16 +482,32 @@ void InfoTab::onNixosManualUpdateRequired() {
 }
 
 void InfoTab::showNixosManualInstructions() {
-  const QString instructions = QString::fromUtf8(
+  const bool dev = updateChannel() == UpdateChannel::Dev;
+  QString instructions = QString::fromUtf8(
       "Không thể tự động cập nhật SKey trên NixOS.\n\n"
       "Hệ thống cần dùng flake với input tên là \"skey\".\n"
       "Thêm vào /etc/nixos/flake.nix:\n\n"
       "  inputs.skey.url = \"github:collyn/skey\";\n\n"
       "Rồi chạy (cần quyền root):\n\n"
-      "  cd /etc/nixos\n"
-      "  sudo nix flake update skey\n"
-      "  sudo nixos-rebuild switch --flake /etc/nixos\n"
-      "  fcitx5 -r -d\n\n"
+      "  cd /etc/nixos\n");
+  if (dev && !pendingVersion_.isEmpty()) {
+    // Dev channel: pin the input to the dev tag and record the dev
+    // version so the build carries the "-dev.N" suffix.
+    instructions += QString::fromUtf8(
+        "  # thêm vào configuration.nix:\n"
+        "  # services.fcitx5-skey.devVersion = \"%1\";\n"
+        "  sudo nix flake lock --override-input skey "
+        "github:collyn/skey/v%1\n"
+        "  sudo nixos-rebuild switch --flake /etc/nixos\n"
+        "  fcitx5 -r -d\n\n")
+        .arg(pendingVersion_);
+  } else {
+    instructions += QString::fromUtf8(
+        "  sudo nix flake update skey\n"
+        "  sudo nixos-rebuild switch --flake /etc/nixos\n"
+        "  fcitx5 -r -d\n\n");
+  }
+  instructions += QString::fromUtf8(
       "Xem chi tiết: https://github.com/collyn/skey/blob/main/"
       "packaging/nixos/README.md");
 

--- a/src/settings/info_tab.h
+++ b/src/settings/info_tab.h
@@ -43,9 +43,12 @@ private slots:
     void onDownloadFailed(const QString &errorMessage);
     void onInstallStarted();
     void onInstallFinished(bool success, const QString &message);
+    void onNixosManualUpdateRequired();
 
 private:
     void setupUI();
+    /// Shared by the no-flake click path and onNixosManualUpdateRequired().
+    void showNixosManualInstructions();
 
     QLabel *versionLabel_;
     QLabel *statusLabel_;

--- a/src/settings/updater.cpp
+++ b/src/settings/updater.cpp
@@ -24,6 +24,21 @@ static const char *kReleasesListUrl =
 // ── Distro detection ─────────────────────────────────────────────────────
 
 Distro Updater::detectDistro() {
+    // NixOS first — must run before the package-manager checks: a dev
+    // shell on NixOS can contain dpkg/rpm/pacman.  /etc/NIXOS is the
+    // canonical marker (present on NixOS containers too); /etc/os-release
+    // is the fallback for nonstandard layouts.
+    if (QFile::exists("/etc/NIXOS"))
+        return Distro::NixOS;
+    {
+        QFile osRelease("/etc/os-release");
+        if (osRelease.open(QIODevice::ReadOnly)) {
+            const QString content = QString::fromUtf8(osRelease.readAll());
+            if (content.contains("ID=nixos") ||
+                content.contains("ID=\"nixos\""))
+                return Distro::NixOS;
+        }
+    }
     // Check package managers — order matters: dnf/rpm first because some
     // Fedora systems may have dpkg installed for cross-build tooling,
     // which would cause a false Debian detection.
@@ -44,6 +59,7 @@ static const char *packageExtension(Distro d) {
     case Distro::Debian:  return ".deb";
     case Distro::Fedora:  return ".rpm";
     case Distro::Arch:    return ".pkg.tar.zst";
+    case Distro::NixOS:   return ""; // never downloaded: rebuild via nix
     case Distro::Unknown: return ".deb"; // fallback
     }
     return ".deb";
@@ -54,6 +70,7 @@ static const char *distroName(Distro d) {
     case Distro::Debian:  return "Debian/Ubuntu";
     case Distro::Fedora:  return "Fedora/RHEL";
     case Distro::Arch:    return "Arch Linux";
+    case Distro::NixOS:   return "NixOS";
     case Distro::Unknown: return "Linux";
     }
     return "Linux";
@@ -76,6 +93,10 @@ static bool assetMatchesDistro(const QString &name, Distro distro) {
     }
     case Distro::Arch:
         return name.endsWith(".pkg.tar.zst") || name.endsWith(".pkg.tar.xz");
+    case Distro::NixOS:
+        // GitHub releases carry no Nix artifact; update goes through
+        // nixos-rebuild, so no asset ever matches.
+        return false;
     case Distro::Unknown:
         // Try all; prefer .deb for backward compat
         return name.endsWith(".deb") || name.endsWith(".rpm") ||
@@ -306,6 +327,13 @@ void Updater::downloadAndInstall(const QString &downloadUrl,
         return;
     }
 
+    if (distro_ == Distro::NixOS) {
+        // Never called: InfoTab routes NixOS through rebuildNixos().
+        emit downloadFailed(QString::fromUtf8(
+            "NixOS không dùng file cài đặt; dùng nixos-rebuild."));
+        return;
+    }
+
     const char *ext = packageExtension(distro_);
     pendingPackagePath_ = QStandardPaths::writableLocation(
                               QStandardPaths::TempLocation) +
@@ -376,6 +404,8 @@ void Updater::onDownloadFinished() {
     case Distro::Arch:
         args = {"pacman", "-U", "--noconfirm", pendingPackagePath_};
         break;
+    case Distro::NixOS:
+        break; // unreachable — guarded above; updates go via rebuildNixos()
     case Distro::Unknown:
         // Fallback: try dpkg (best-effort)
         args = {"dpkg", "-i", pendingPackagePath_};
@@ -416,4 +446,66 @@ void Updater::onDownloadFinished() {
             });
 
     proc->start(program, args);
+}
+
+// ── NixOS: rebuild instead of download ───────────────────────────────────
+
+void Updater::rebuildNixos() {
+    if (distro_ != Distro::NixOS)
+        return;
+
+    // pkexec sanitizes PATH (secure default — no /run/current-system/sw),
+    // so use absolute paths; they exist on every NixOS system.  /bin/sh
+    // is guaranteed on NixOS.  Exit codes: 0 = success, 42 = `nix flake
+    // update skey` failed (input missing/not named `skey`) → manual
+    // instructions; pkexec itself returns 126 on auth cancel/deny.
+    static const char *kNix = "/run/current-system/sw/bin/nix";
+    static const char *kRebuild = "/run/current-system/sw/bin/nixos-rebuild";
+    if (!QFile::exists(kNix) || !QFile::exists(kRebuild)) {
+        emit nixosManualUpdateRequired();
+        return;
+    }
+
+    // No download, so no downloadProgress/downloadFinished will fire.
+    emit installStarted();
+
+    // Root's nix.conf does not enable flakes by default, so pass the
+    // experimental features explicitly; nixos-rebuild adds its own flags.
+    const QString script =
+        QStringLiteral("cd /etc/nixos || exit 42\n"
+                       "%1 --extra-experimental-features 'nix-command flakes'"
+                       " flake update skey || exit 42\n"
+                       "%2 switch --flake /etc/nixos")
+            .arg(QString::fromLatin1(kNix), QString::fromLatin1(kRebuild));
+
+    auto *proc = new QProcess(this);
+    connect(proc,
+            static_cast<void (QProcess::*)(int, QProcess::ExitStatus)>(
+                &QProcess::finished),
+            this, [this, proc](int exitCode, QProcess::ExitStatus) {
+                QString errOutput =
+                    QString::fromUtf8(proc->readAllStandardError());
+                proc->deleteLater();
+
+                if (exitCode == 0) {
+                    emit installFinished(
+                        true,
+                        QString::fromUtf8(
+                            "Cập nhật thành công! Hệ thống đã được build "
+                            "lại bằng nixos-rebuild."));
+                } else if (exitCode == 42) {
+                    emit nixosManualUpdateRequired();
+                } else {
+                    emit installFinished(
+                        false,
+                        QString::fromUtf8("Cập nhật thất bại (mã %1): %2")
+                            .arg(exitCode)
+                            .arg(errOutput.isEmpty()
+                                     ? QString::fromUtf8("Người dùng đã hủy "
+                                                         "hoặc lỗi quyền.")
+                                     : errOutput));
+                }
+            });
+
+    proc->start("pkexec", {"/bin/sh", "-c", script});
 }

--- a/src/settings/updater.cpp
+++ b/src/settings/updater.cpp
@@ -450,7 +450,7 @@ void Updater::onDownloadFinished() {
 
 // ── NixOS: rebuild instead of download ───────────────────────────────────
 
-void Updater::rebuildNixos() {
+void Updater::rebuildNixos(const QString &version) {
     if (distro_ != Distro::NixOS)
         return;
 
@@ -471,12 +471,57 @@ void Updater::rebuildNixos() {
 
     // Root's nix.conf does not enable flakes by default, so pass the
     // experimental features explicitly; nixos-rebuild adds its own flags.
-    const QString script =
-        QStringLiteral("cd /etc/nixos || exit 42\n"
-                       "%1 --extra-experimental-features 'nix-command flakes'"
-                       " flake update skey || exit 42\n"
-                       "%2 switch --flake /etc/nixos")
-            .arg(QString::fromLatin1(kNix), QString::fromLatin1(kRebuild));
+    const QString flakeFeatures =
+        QStringLiteral("--extra-experimental-features 'nix-command flakes'");
+
+    // Marker comments in configuration.nix that the GUI itself manages.
+    // Their presence means the dev channel is active (input pinned to a
+    // dev tag), so a stable update must first undo both the devVersion
+    // line and the input override (--override-input persists in flake.lock).
+    const QString devBegin =
+        QString::fromUtf8("# ── fcitx5-skey dev channel (settings GUI) ──");
+    const QString devEnd =
+        QString::fromUtf8("# ── end fcitx5-skey dev channel ──");
+    const QString configPath = QStringLiteral("/etc/nixos/configuration.nix");
+
+    const bool dev = activeChannel_ == UpdateChannel::Dev;
+    QString script = QStringLiteral("cd /etc/nixos || exit 42\n");
+
+    if (dev) {
+        // Dev channel: pin the input to the exact dev prerelease tag — the
+        // same source the .deb/.rpm dev package is built from — and record
+        // the dev version so the rebuilt package carries the dev suffix
+        // (otherwise the updater would re-offer the same dev tag forever).
+        script +=
+            QStringLiteral("sed -i '/%1/,/%2/d' %3 2>/dev/null || true\n"
+                           "cat >> %3 <<'SKEOF'\n"
+                           "%1\n"
+                           "services.fcitx5-skey.devVersion = \"%4\";\n"
+                           "%2\n"
+                           "SKEOF\n"
+                           "%5 %6 flake lock --override-input skey"
+                           " github:collyn/skey/v%4 || exit 42\n"
+                           "%7 switch --flake /etc/nixos\n")
+                .arg(devBegin, devEnd, configPath, version,
+                     QString::fromLatin1(kNix), flakeFeatures,
+                     QString::fromLatin1(kRebuild));
+    } else {
+        // Stable: when the dev block is present, drop it and reset the
+        // input override back to the default branch; otherwise leave the
+        // user's own input untouched.
+        script +=
+            QStringLiteral("if grep -q '%1' %3; then\n"
+                           "  sed -i '/%1/,/%2/d' %3\n"
+                           "  %5 %6 flake lock --override-input skey"
+                           " github:collyn/skey || exit 42\n"
+                           "else\n"
+                           "  %5 %6 flake update skey || exit 42\n"
+                           "fi\n"
+                           "%7 switch --flake /etc/nixos\n")
+                .arg(devBegin, devEnd, configPath, version,
+                     QString::fromLatin1(kNix), flakeFeatures,
+                     QString::fromLatin1(kRebuild));
+    }
 
     auto *proc = new QProcess(this);
     connect(proc,

--- a/src/settings/updater.cpp
+++ b/src/settings/updater.cpp
@@ -364,7 +364,7 @@ void Updater::onDownloadFinished() {
         // plain `dpkg -i` fails with "dependency problems" whenever the
         // new package adds a dependency the system doesn't have yet.
         if (!QStandardPaths::findExecutable("apt-get").isEmpty()) {
-            args = {"apt-get", "install", "-y", pendingPackagePath_};
+            args = {"apt-get", "install", "-y", "--allow-downgrades", pendingPackagePath_};
         } else {
             args = {"dpkg", "-i", pendingPackagePath_};
         }

--- a/src/settings/updater.h
+++ b/src/settings/updater.h
@@ -24,10 +24,13 @@ public:
     void downloadAndInstall(const QString &downloadUrl, const QString &version);
 
     /// NixOS: run `nix flake update skey` + `nixos-rebuild switch` via
-    /// pkexec (no download).  Emits installStarted() then
-    /// installFinished(), or nixosManualUpdateRequired() when manual
-    /// action is needed.
-    void rebuildNixos();
+    /// pkexec (no download).  Stable channel follows the default branch;
+    /// dev channel pins the input to the dev prerelease tag and records
+    /// `services.fcitx5-skey.devVersion` in configuration.nix so the
+    /// rebuilt package carries the dev version string.  Emits
+    /// installStarted() then installFinished(), or
+    /// nixosManualUpdateRequired() when manual action is needed.
+    void rebuildNixos(const QString &version);
 
     /// Detect which distro family we're running on.
     static Distro detectDistro();

--- a/src/settings/updater.h
+++ b/src/settings/updater.h
@@ -11,7 +11,7 @@ class QNetworkAccessManager;
 class QNetworkReply;
 
 /// Supported Linux distro families for package management.
-enum class Distro { Debian, Fedora, Arch, Unknown };
+enum class Distro { Debian, Fedora, Arch, NixOS, Unknown };
 
 class Updater : public QObject {
     Q_OBJECT
@@ -23,8 +23,16 @@ public:
     void setChannel(UpdateChannel channel);
     void downloadAndInstall(const QString &downloadUrl, const QString &version);
 
+    /// NixOS: run `nix flake update skey` + `nixos-rebuild switch` via
+    /// pkexec (no download).  Emits installStarted() then
+    /// installFinished(), or nixosManualUpdateRequired() when manual
+    /// action is needed.
+    void rebuildNixos();
+
     /// Detect which distro family we're running on.
     static Distro detectDistro();
+    /// Distro detected when this Updater was constructed.
+    Distro distro() const { return distro_; }
 
 signals:
     void updateAvailable(const QString &newVersion,
@@ -39,6 +47,11 @@ signals:
 
     void installStarted();
     void installFinished(bool success, const QString &message);
+
+    /// NixOS: auto-update cannot proceed (no /etc/nixos/flake.nix, input
+    /// not named `skey`, or the nix CLI is missing).  The UI must show
+    /// copyable manual commands.
+    void nixosManualUpdateRequired();
 
 private slots:
     void onCheckReplyFinished();


### PR DESCRIPTION
- **fix: prefer SVG icons in info tab and fix HiDPI icon overflow**
- **fix: correct icon scaling in appearance and info tabs, and allow downgrades during apt-get package updates**
- **chore: bump project version to 0.7.7**
- **feat: add native NixOS support with flake-based module and system-rebuild updater**
- **docs: update project README with latest configuration and setup instructions**
- **feat: add NixOS dev channel support with automated flake input pinning and versioning in configuration.nix**
