### PR TITLE
dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(fcitx5-skey VERSION 0.7.11)
+project(fcitx5-skey VERSION 0.7.12)
 
 # Version compiled into the settings GUI / updater.  Dev builds append a
 # suffix (e.g. 0.7.5~dev.123) — project() VERSION must stay purely numeric,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ fcitx5_add_i18n_definition()
 #             tree stays clean.  skey_engine.h is also taken from the source.
 #   CI:     no SKEY_ENGINE_SOURCE_DIR
 #           → clones the pinned tag from GitHub (used by GitHub Actions).
-set(SKEY_ENGINE_VERSION "v0.1.23")
+set(SKEY_ENGINE_VERSION "v0.1.24")
 set(SKEY_ENGINE_DIR "${CMAKE_CURRENT_BINARY_DIR}/skey-engine")
 # Point to a prebuilt libskey_engine.a to skip the cargo build entirely —
 # for build sandboxes without network access (e.g. NixOS/nixpkgs), where the

--- a/src/a11y_monitor.cpp
+++ b/src/a11y_monitor.cpp
@@ -164,6 +164,46 @@ static int queryProcessId(DBusConnection *bus, const char *sender,
     return pid;
 }
 
+// Resolve the pid of the focused app's AT-SPI connection via the a11y
+// registry (org.a11y.Bus on the session bus) instead of round-tripping
+// to the app.  GetProcessId on browser-UI elements can stall AT-SPI,
+// and non-web apps (which skip GetProcessId) otherwise leave pid=-1,
+// forcing the engine into full /proc scans — which can misclassify.
+// The registry answers from its own bookkeeping, so it cannot stall.
+static int queryConnectionPid(const char *sender) {
+    DBusError err;
+    dbus_error_init(&err);
+    DBusConnection *session = dbus_bus_get(DBUS_BUS_SESSION, &err);
+    if (!session || dbus_error_is_set(&err)) {
+        dbus_error_free(&err);
+        return -1;
+    }
+    DBusMessage *msg = dbus_message_new_method_call(
+        "org.a11y.Bus", "/org/a11y/bus", "org.a11y.Bus",
+        "GetConnectionUnixProcessID");
+    if (!msg) {
+        dbus_connection_unref(session);
+        return -1;
+    }
+    dbus_message_append_args(msg, DBUS_TYPE_STRING, &sender,
+                             DBUS_TYPE_INVALID);
+    DBusMessage *reply = dbus_connection_send_with_reply_and_block(
+        session, msg, 500, &err);
+    dbus_message_unref(msg);
+
+    int pid = -1;
+    if (reply && !dbus_error_is_set(&err)) {
+        dbus_int32_t p = -1;
+        if (dbus_message_get_args(reply, &err, DBUS_TYPE_INT32, &p,
+                                  DBUS_TYPE_INVALID))
+            pid = static_cast<int>(p);
+        dbus_message_unref(reply);
+    }
+    dbus_error_free(&err);
+    dbus_connection_unref(session);
+    return pid;
+}
+
 static int queryRole(DBusConnection *bus, const char *sender,
                      const char *path) {
     DBusError err;
@@ -791,16 +831,19 @@ void A11yMonitor::threadFunc() {
                     int role = queryRole(bus, sender, path);
                     bool hasDocWeb = hasDocumentWebAncestor(
                         bus, sender, path);
-                    // Only query GetProcessId for web content.  Browser-UI
-                    // elements (the Chromium omnibox) can stall AT-SPI
-                    // calls, and on X11 the autosuggest polling shares
-                    // this monitor thread — a stuck reply here delays the
-                    // polling snapshot and breaks autofill detection.
-                    // Non-web-doc apps (terminals...) fall back to the
-                    // full /proc scan in the engine.
+                    // Only query the app directly for web content.
+                    // Browser-UI elements (the Chromium omnibox) can
+                    // stall AT-SPI calls, and on X11 the autosuggest
+                    // polling shares this monitor thread — a stuck reply
+                    // here delays the polling snapshot and breaks autofill
+                    // detection.  For everything else resolve the pid
+                    // through the a11y registry on the session bus (no app
+                    // round-trip, cannot stall) so the engine gets a
+                    // verified pid instead of falling back to full
+                    // /proc scans.
                     int procId = hasDocWeb
                                      ? queryProcessId(bus, sender, path)
-                                     : -1;
+                                     : queryConnectionPid(sender);
                     focusProcessId_.store(procId,
                                           std::memory_order_relaxed);
                     bool isUI = !hasDocWeb;

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1442,6 +1442,10 @@ static constexpr uint64_t kChromiumStrongHints =
 /// updated (some apps re-sync their text-input state) or the AT-SPI2 focus
 /// event lands and provides the web-editor signal (see a11yFreshWebEditor).
 static constexpr uint64_t kBareCapsDecisionWindowUsec = 2000000; // 2s
+// Surr-mode lazy re-attach: a reset arriving within this window after our
+// own keystroke is treated as the app's reaction (zen fires one after
+// every key), not a focus change.
+static constexpr uint64_t kSurrReattachWindowUsec = 500000; // 500ms
 
 bool SKeyState::a11yFreshWebEditor() const {
   auto *mon = engine_->a11yMonitor();
@@ -1912,6 +1916,8 @@ void SKeyState::activate() {
   // apps — the focused X11 window may have changed.
   appNameAttempted_ = false;
   resolvedProgram_.clear();
+  // Fresh focus: no tentative word state carries over.
+  surrResetTentative_ = false;
 
   // Reactivate after spurious cycle: cancel the genuine-loss timer.
   if (addrBarExpectCycle_) {
@@ -2610,6 +2616,8 @@ void SKeyState::deactivate() {
                << " seenBs=" << seenUinputBackspaces_ << " pendingCommit='"
                << pendingUinputCommit_ << "'";
   lastDeactivateTime_ = now(CLOCK_MONOTONIC);
+  // Genuine focus loss: any Surr tentative word state is gone with it.
+  surrResetTentative_ = false;
   forceFlushDeferredCommit();
   // Stop a11y snapshot polling — re-enabled on the next addrbar key.
   if (auto *mon = engine_->a11yMonitor()) {
@@ -2725,6 +2733,21 @@ void SKeyState::reset() {
     uinputKeyForwarded_ = false;
     return;
   }
+  // Surr-mode lazy re-attach: some apps (zen) fire a reset right after
+  // every keystroke — the app's reaction to our commit, not a focus
+  // change.  If this reset lands within the re-attach window of our own
+  // last key, keep the word state (viet_, lastWord, committedLen_, mode
+  // cache); the next key re-validates against the surrounding text (see
+  // keyEvent) before continuing.  A genuine focus change arrives later,
+  // or is caught by the surrounding-text mismatch.
+  if (useSurroundingText() && !viet_.getComposed().empty() &&
+      !hasDeferredCommitPending() && surrLastKeyUsec_ > 0 &&
+      now(CLOCK_MONOTONIC) - surrLastKeyUsec_ <= kSurrReattachWindowUsec) {
+    surrResetTentative_ = true;
+    SKEY_DEBUG() << "Reset: Surr tentative keep '" << viet_.getComposed()
+                 << "'";
+    return;
+  }
   if (hasDeferredCommitPending()) {
     SKEY_DEBUG() << "Reset: keeping deferred commit";
   }
@@ -2764,8 +2787,43 @@ void SKeyState::keyEvent(KeyEvent &keyEvent) {
     return;
   }
 
+  surrLastKeyUsec_ = now(CLOCK_MONOTONIC);
+
   // Refresh per-app mode in case IC is shared across apps
   refreshAppMode();
+
+  // Lazy re-attach validation: a Surr-mode reset kept the word state
+  // (see reset()) — confirm or discard it on this first key.  Real
+  // surrounding text wins when available: the word must sit immediately
+  // before the cursor.  Empty/invalid surrounding (zen URL bar pushes
+  // none) trusts the time-based arm done in reset().
+  if (surrResetTentative_) {
+    surrResetTentative_ = false;
+    bool keep = useSurroundingText();
+    if (keep) {
+      const auto &surrounding = ic_->surroundingText();
+      if (surrounding.isValid() && !surrounding.text().empty()) {
+        const std::string &word = viet_.getComposed();
+        const std::string &text = surrounding.text();
+        size_t cursor = surrounding.cursor();
+        size_t wordChars = utf8::length(word);
+        size_t cursorBytes = utf8::ncharByteLength(text.begin(), cursor);
+        keep = cursor >= wordChars && cursorBytes >= word.size() &&
+               text.compare(cursorBytes - word.size(), word.size(), word) ==
+                   0;
+      }
+    }
+    if (!keep) {
+      SKEY_DEBUG() << "Reset: tentative discarded, surrounding mismatch";
+      viet_.reset();
+      committedLen_ = 0;
+      clearLastWord();
+      clearUI();
+    } else {
+      SKEY_DEBUG() << "Reset: tentative confirmed, continuing '"
+                   << viet_.getComposed() << "'";
+    }
+  }
 
   // Deferred mode decision (bare Chromium caps): re-evaluate at word
   // boundaries so a content-type update that arrived after focus (e.g.

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -364,6 +364,53 @@ static bool isChromiumBrowser(const std::string &prog) {
   return false;
 }
 
+// Check a single binary's own path for Chromium/Electron markers.
+// Deliberately process-own only: ancestor chains are not evidence — an
+// app launched from an Electron terminal must not inherit the parent's
+// classification (observed with zen: the ancestor walk misclassified the
+// Firefox fork as Chromium and its bare-caps sticky locked it to Uinput).
+// Renamed Electron shells are caught by chrome-sandbox /
+// chrome_crashpad_handler next to their own binary.
+static bool exeHasChromiumMarkers(const std::string &exe) {
+  std::string lower = exe;
+  std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
+  if (lower.find("electron") != std::string::npos ||
+      lower.find("chrome") != std::string::npos ||
+      lower.find("chromium") != std::string::npos) {
+    return true;
+  }
+  size_t lastSlash = exe.rfind('/');
+  if (lastSlash != std::string::npos) {
+    std::string exeDir = exe.substr(0, lastSlash);
+    if (access((exeDir + "/chrome-sandbox").c_str(), F_OK) == 0 ||
+        access((exeDir + "/chrome_crashpad_handler").c_str(), F_OK) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Firefox-family marker: Gecko browsers always ship libxul.so next to
+// their main binary — a binary-layout check instead of hardcoding app
+// names (covers zen, librewolf, ...).
+static bool processHasGeckoMarker(pid_t pid) {
+  char exeBuf[PATH_MAX];
+  std::string exePath = "/proc/" + std::to_string(pid) + "/exe";
+  ssize_t len = readlink(exePath.c_str(), exeBuf, sizeof(exeBuf) - 1);
+  if (len > 0) {
+    exeBuf[len] = '\0';
+    std::string exe(exeBuf);
+    size_t lastSlash = exe.rfind('/');
+    if (lastSlash != std::string::npos) {
+      std::string exeDir = exe.substr(0, lastSlash);
+      if (access((exeDir + "/libxul.so").c_str(), F_OK) == 0) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
 // Matches Chromium-family browsers AND Electron-based apps.
 // Electron apps share Chromium's multi-process architecture and need the
 // same BackSpace→commit timing adjustments.  Use this for everything
@@ -426,74 +473,20 @@ static bool isChromiumBasedApp(const std::string &prog) {
       }
     }
 
-    // Found matching process — check ancestry for Chromium markers
-    int ppid = 0;
-    for (int depth = 0; depth < 10; depth++) {
-      std::string checkPid = (depth == 0) ? pidStr : std::to_string(ppid);
-
-      // Check exe symlink
-      char exeBuf[PATH_MAX];
-      std::string exePath = "/proc/" + checkPid + "/exe";
-      ssize_t len = readlink(exePath.c_str(), exeBuf, sizeof(exeBuf) - 1);
-      if (len > 0) {
-        exeBuf[len] = '\0';
-        std::string exe(exeBuf);
-        std::string lower = exe;
-        std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
-        if (lower.find("electron") != std::string::npos ||
-            lower.find("chrome") != std::string::npos ||
-            lower.find("chromium") != std::string::npos) {
-          closedir(dir);
-          return true;
-        }
-
-        // chrome-sandbox in the same directory = Electron app
-        size_t lastSlash = exe.rfind('/');
-        if (lastSlash != std::string::npos) {
-          std::string exeDir = exe.substr(0, lastSlash);
-          if (access((exeDir + "/chrome-sandbox").c_str(), F_OK) == 0) {
-            closedir(dir);
-            return true;
-          }
-          if (access((exeDir + "/chrome_crashpad_handler").c_str(), F_OK) ==
-              0) {
-            closedir(dir);
-            return true;
-          }
-        }
-      }
-
-      // Walk up to parent
-      if (depth == 0) {
-        std::string statPath = "/proc/" + pidStr + "/stat";
-        std::ifstream statFile(statPath);
-        if (!statFile.is_open())
-          break;
-        std::string statLine;
-        std::getline(statFile, statLine);
-        size_t rparen = statLine.rfind(')');
-        if (rparen == std::string::npos)
-          break;
-        std::istringstream iss(statLine.substr(rparen + 2));
-        std::string state;
-        iss >> state >> ppid;
-      } else {
-        std::string pstatPath = "/proc/" + std::to_string(ppid) + "/stat";
-        std::ifstream pstatFile(pstatPath);
-        if (!pstatFile.is_open())
-          break;
-        std::string pstatLine;
-        std::getline(pstatFile, pstatLine);
-        size_t rparen = pstatLine.rfind(')');
-        if (rparen == std::string::npos)
-          break;
-        std::istringstream piss(pstatLine.substr(rparen + 2));
-        std::string state;
-        int newPpid;
-        piss >> state >> newPpid;
-        if (newPpid <= 1 || newPpid == ppid)
-          break;
-        ppid = newPpid;
+    // Found matching process — check its OWN binary for markers.
+    // Ancestors are deliberately NOT examined: launch origin is not
+    // evidence of the binary's nature — a Firefox fork started from an
+    // Electron terminal was misclassified as Chromium by the ancestor
+    // walk (zen).  Renamed Electron shells are caught by chrome-sandbox
+    // / chrome_crashpad_handler next to their own binary.
+    char exeBuf[PATH_MAX];
+    std::string exePath = "/proc/" + pidStr + "/exe";
+    ssize_t exeLen = readlink(exePath.c_str(), exeBuf, sizeof(exeBuf) - 1);
+    if (exeLen > 0) {
+      exeBuf[exeLen] = '\0';
+      if (exeHasChromiumMarkers(exeBuf)) {
+        closedir(dir);
+        return true;
       }
     }
   }
@@ -535,47 +528,18 @@ static bool isTerminalAppName(const std::string &prog) {
 // directory ships chrome-sandbox / chrome_crashpad_handler (renamed
 // Electron shells like antigravity).  Bounded to 10 generations.
 static bool processHasChromiumMarkers(pid_t pid) {
-  int cur = static_cast<int>(pid);
-  for (int depth = 0; depth < 10; ++depth) {
-    std::string checkPid = std::to_string(cur);
-    char exeBuf[PATH_MAX];
-    std::string exePath = "/proc/" + checkPid + "/exe";
-    ssize_t len = readlink(exePath.c_str(), exeBuf, sizeof(exeBuf) - 1);
-    if (len > 0) {
-      exeBuf[len] = '\0';
-      std::string lower(exeBuf);
-      std::transform(lower.begin(), lower.end(), lower.begin(), ::tolower);
-      if (lower.find("electron") != std::string::npos ||
-          lower.find("chrome") != std::string::npos ||
-          lower.find("chromium") != std::string::npos) {
-        return true;
-      }
-      size_t lastSlash = lower.rfind('/');
-      if (lastSlash != std::string::npos) {
-        std::string exeDir = lower.substr(0, lastSlash);
-        if (access((exeDir + "/chrome-sandbox").c_str(), F_OK) == 0 ||
-            access((exeDir + "/chrome_crashpad_handler").c_str(), F_OK) ==
-                0) {
-          return true;
-        }
-      }
+  // The pid has already been verified to belong to the app (comm match
+  // in a11yAppPid) — only its OWN binary is evidence.  Ancestors are
+  // not checked: an app launched from an Electron terminal must not
+  // inherit the parent's classification (zen false-positive).
+  char exeBuf[PATH_MAX];
+  std::string exePath = "/proc/" + std::to_string(pid) + "/exe";
+  ssize_t len = readlink(exePath.c_str(), exeBuf, sizeof(exeBuf) - 1);
+  if (len > 0) {
+    exeBuf[len] = '\0';
+    if (exeHasChromiumMarkers(exeBuf)) {
+      return true;
     }
-    std::string statPath = "/proc/" + checkPid + "/stat";
-    std::ifstream statFile(statPath);
-    if (!statFile.is_open())
-      break;
-    std::string statLine;
-    std::getline(statFile, statLine);
-    size_t rparen = statLine.rfind(')');
-    if (rparen == std::string::npos)
-      break;
-    std::istringstream iss(statLine.substr(rparen + 2));
-    std::string state;
-    int ppid = 0;
-    iss >> state >> ppid;
-    if (ppid <= 1 || ppid == cur)
-      break;
-    cur = ppid;
   }
   return false;
 }
@@ -1821,12 +1785,17 @@ bool SKeyState::isFirefoxOrSnap() const {
     cachedIsFirefoxOrSnap_ = 1;
     return true;
   }
+  // Firefox forks (zen, ...) are recognized by their binary layout:
+  // Gecko browsers ship libxul.so next to the main executable.  They
+  // share Firefox's reset-after-forwarded-key behavior and need the
+  // same state-preservation guards.
   // Detect Snap-packaged apps: prefer the a11y-reported PID (one readlink,
   // no scan) and fall back to the full /proc scan.
   if (!prog.empty()) {
     int pid = a11yAppPid();
     if (pid > 0) {
-      cachedIsFirefoxOrSnap_ = processIsSnapPid(pid) ? 1 : 0;
+      cachedIsFirefoxOrSnap_ =
+          (processHasGeckoMarker(pid) || processIsSnapPid(pid)) ? 1 : 0;
       return cachedIsFirefoxOrSnap_ == 1;
     }
     DIR *dir = opendir("/proc");
@@ -1851,6 +1820,15 @@ bool SKeyState::isFirefoxOrSnap() const {
             buf[len] = '\0';
             std::string exe(buf);
             if (exe.find("/snap/") != std::string::npos) {
+              closedir(dir);
+              cachedIsFirefoxOrSnap_ = 1;
+              return true;
+            }
+            // Gecko fork: libxul.so next to the main binary
+            size_t lastSlash = exe.rfind('/');
+            if (lastSlash != std::string::npos &&
+                access((exe.substr(0, lastSlash) + "/libxul.so").c_str(),
+                       F_OK) == 0) {
               closedir(dir);
               cachedIsFirefoxOrSnap_ = 1;
               return true;

--- a/src/engine.h
+++ b/src/engine.h
@@ -276,6 +276,12 @@ private:
     bool reclaimReady_ = false;     // True after BS pressed while idle
     bool sepAlreadyDeleted_ = false; // Separator already deleted by first BS
     bool wordWasBackspaced_ = false; // Word deleted by backspace, block reclaim
+    // Lazy re-attach (zen's per-key reset storm in Surr mode): reset()
+    // that arrives right after our own keystroke is the app's reaction,
+    // not a focus change — keep the word state and validate on the next
+    // key against the surrounding text.
+    bool surrResetTentative_ = false;
+    uint64_t surrLastKeyUsec_ = 0; // last keyEvent time (CLOCK_MONOTONIC)
     bool addrBarDidFullReplace_ = false; // FullReplace done, reset engine on commit
     bool addrBarHadFirstWord_ = false;  // First word already done, block fullReplace
     bool addrBarKeepState_ = false;     // Keep-state active, reset engine on BS

--- a/src/test_vietnamese.cpp
+++ b/src/test_vietnamese.cpp
@@ -663,19 +663,23 @@ int main(int argc, char **argv) {
              skey::InputMethod::Telex, "bcdd", "bcđ",
              "ddFreeStyle protects: no vowel + has đ → keep"});
 
-    // dd marker protects regardless of vowels (engine-level
-    // has_vn_markers) — intentional đ composition is never restored.
+    // dd after a CONSONANT is an intentional đ (engine-level
+    // has_vn_markers) — the composition is never restored.
     runTest({cat, "avcdd → avcđ (dd marker protected)",
              skey::InputMethod::Telex, "avcdd", "avcđ",
              "dd signals intentional đ — auto-restore skips", false, false,
              true});
 
-    runTest({cat, "add → ađ (dd marker protected)", skey::InputMethod::Telex,
-             "add", "ađ", "dd signals intentional đ — auto-restore skips",
-             false, false, true});
+    // English dd after a VOWEL is not an intentional đ — auto-restore
+    // returns the raw word (address, add, odd, ladder).
+    runTest({cat, "add → add (English dd after vowel restored)",
+             skey::InputMethod::Telex, "add", "add",
+             "dd after a vowel is English — auto-restore keeps raw", false,
+             false, true});
 
-    runTest({cat, "addr → ảđ (dd marker protected)", skey::InputMethod::Telex,
-             "addr", "ảđ", "dd→đ then r=hỏi on a; marker blocks restore", false,
+    runTest({cat, "addr → addr (English dd after vowel restored)",
+             skey::InputMethod::Telex, "addr", "addr",
+             "dd after a vowel is English — auto-restore keeps raw", false,
              false, true});
 
     // nđm: ddFreeStyle protected (no vowel, has đ)
@@ -729,14 +733,19 @@ int main(int argc, char **argv) {
              "digits are ignored unless VNI mode; 'abc' stays, 123 ignored "
              "individually"});
 
-    // "address" — dd marker protects the đ during composition; the
-    // trailing double tone keys trigger P5, which strips every tone
-    // key after the first vowel (including hỏi 'r') and commits the
-    // raw base + final 's'.
-    runTest({cat, "address → addes (dd marker + P5 tone strip)",
-             skey::InputMethod::Telex, "address", "addes",
-             "dd→đ protected; P5 strips r,s,s after first vowel", false, false,
-             true});
+    // "address" — English dd after a vowel: auto-restore keeps the raw
+    // word at every intermediate stage, so no tone/undo path fires.
+    runTest({cat, "address → address (English dd after vowel restored)",
+             skey::InputMethod::Telex, "address", "address",
+             "dd after a vowel is English — auto-restore keeps raw", false,
+             false, true});
+
+    // Unikey-style English typing: "doww" toggles the ơ off and the rest
+    // of the word must compose literally — not corrupt into "đôwnla".
+    runTest({cat, "dowwnload → download (Unikey-style toggle-off word)",
+             skey::InputMethod::Telex, "dowwnload", "download",
+             "doww→dow un-hooks; after toggle-off transform keys are literal",
+             false, false, true});
 
     // "reboot" — oo→ô transform, real-time restore works.
     runTest({cat, "reboot → reboot (real-time restore)",


### PR DESCRIPTION
- **refactor: switch to direct process-binary marker detection and non-blocking AT-SPI registry PID resolution**
- **feat: implement lazy re-attach logic in Surr-mode to prevent spurious word state loss during per-key reset events**
- **chore: update SKEY_ENGINE_VERSION to v0.1.24**
- **chore: bump project version to 0.7.12**
