### PR TITLE
dev

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(fcitx5-skey VERSION 0.8.1)
+project(fcitx5-skey VERSION 0.8.2)
 
 # Version compiled into the settings GUI / updater.  Dev builds append a
 # suffix (e.g. 0.7.5~dev.123) — project() VERSION must stay purely numeric,

--- a/src/a11y_monitor.cpp
+++ b/src/a11y_monitor.cpp
@@ -140,8 +140,15 @@ static DBusConnection *connectAtspiBus() {
 // AT-SPI2 accessible queries
 // ---------------------------------------------------------------------------
 
-static int queryProcessId(DBusConnection *bus, const char *sender,
-                          const char *path) {
+// Per-element pid of the focused accessible (GetProcessId round-trip to
+// the app).  Only queried for WEB content (browser-UI elements can stall
+// AT-SPI and block the shared monitor thread).  On old Chrome this
+// returned the per-tab RENDERER pid — the per-input identity visible in
+// the Focus log; Chrome ≥150's native a11y answers -1 for it, which is
+// why the engine no longer relies on it.  Kept as a log/analysis signal
+// only (focusElementPid_), NOT consumed by the engine.
+static int queryElementPid(DBusConnection *bus, const char *sender,
+                           const char *path) {
     DBusError err;
     dbus_error_init(&err);
     DBusMessage *msg = dbus_message_new_method_call(
@@ -149,7 +156,7 @@ static int queryProcessId(DBusConnection *bus, const char *sender,
     if (!msg) return -1;
 
     DBusMessage *reply = dbus_connection_send_with_reply_and_block(
-        bus, msg, 500, &err);
+        bus, msg, 200, &err);
     dbus_message_unref(msg);
 
     int pid = -1;
@@ -164,43 +171,43 @@ static int queryProcessId(DBusConnection *bus, const char *sender,
     return pid;
 }
 
-// Resolve the pid of the focused app's AT-SPI connection via the a11y
-// registry (org.a11y.Bus on the session bus) instead of round-tripping
-// to the app.  GetProcessId on browser-UI elements can stall AT-SPI,
-// and non-web apps (which skip GetProcessId) otherwise leave pid=-1,
-// forcing the engine into full /proc scans — which can misclassify.
-// The registry answers from its own bookkeeping, so it cannot stall.
-static int queryConnectionPid(const char *sender) {
+// Resolve the pid of the focused app's AT-SPI connection via the D-Bus
+// daemon (GetConnectionUnixProcessID on org.freedesktop.DBus) instead of
+// round-tripping to the app.  GetProcessId on Chromium's a11y objects is
+// unreliable: browser-UI elements can stall AT-SPI (blocking the shared
+// monitor thread), and Chrome ≥150's native-a11y mode simply returns -1
+// for it.  The daemon answers from its own bookkeeping and cannot stall.
+// NOTE: this method lives on org.freedesktop.DBus (path
+// /org/freedesktop/DBus) — org.a11y.Bus has NO such method.  It must be
+// called on the SAME bus the monitor is connected to: accessibility runs
+// on a DEDICATED at-spi bus (/run/user/<uid>/at-spi/bus_0), and the
+// senders' unique names only resolve there — calling the session bus
+// silently returns -1 for every focus event (both bugs fixed
+// 2026-09-07).
+static int queryConnectionPid(DBusConnection *bus, const char *sender) {
     DBusError err;
     dbus_error_init(&err);
-    DBusConnection *session = dbus_bus_get(DBUS_BUS_SESSION, &err);
-    if (!session || dbus_error_is_set(&err)) {
-        dbus_error_free(&err);
-        return -1;
-    }
     DBusMessage *msg = dbus_message_new_method_call(
-        "org.a11y.Bus", "/org/a11y/bus", "org.a11y.Bus",
-        "GetConnectionUnixProcessID");
+        "org.freedesktop.DBus", "/org/freedesktop/DBus",
+        "org.freedesktop.DBus", "GetConnectionUnixProcessID");
     if (!msg) {
-        dbus_connection_unref(session);
         return -1;
     }
     dbus_message_append_args(msg, DBUS_TYPE_STRING, &sender,
                              DBUS_TYPE_INVALID);
     DBusMessage *reply = dbus_connection_send_with_reply_and_block(
-        session, msg, 500, &err);
+        bus, msg, 500, &err);
     dbus_message_unref(msg);
 
     int pid = -1;
     if (reply && !dbus_error_is_set(&err)) {
-        dbus_int32_t p = -1;
-        if (dbus_message_get_args(reply, &err, DBUS_TYPE_INT32, &p,
+        dbus_uint32_t p = 0; // reply signature is 'u'
+        if (dbus_message_get_args(reply, &err, DBUS_TYPE_UINT32, &p,
                                   DBUS_TYPE_INVALID))
             pid = static_cast<int>(p);
         dbus_message_unref(reply);
     }
     dbus_error_free(&err);
-    dbus_connection_unref(session);
     return pid;
 }
 
@@ -831,21 +838,27 @@ void A11yMonitor::threadFunc() {
                     int role = queryRole(bus, sender, path);
                     bool hasDocWeb = hasDocumentWebAncestor(
                         bus, sender, path);
-                    // Only query the app directly for web content.
-                    // Browser-UI elements (the Chromium omnibox) can
-                    // stall AT-SPI calls, and on X11 the autosuggest
-                    // polling shares this monitor thread — a stuck reply
-                    // here delays the polling snapshot and breaks autofill
-                    // detection.  For everything else resolve the pid
-                    // through the a11y registry on the session bus (no app
-                    // round-trip, cannot stall) so the engine gets a
-                    // verified pid instead of falling back to full
-                    // /proc scans.
-                    int procId = hasDocWeb
-                                     ? queryProcessId(bus, sender, path)
-                                     : queryConnectionPid(sender);
+                    // Resolve the pid through the D-Bus daemon for every
+                    // focus event (web content included).  GetProcessId on
+                    // Chromium's a11y objects stalls on browser-UI
+                    // elements (blocking the shared monitor thread and the
+                    // X11 autosuggest polling) and Chrome ≥150's native
+                    // a11y answers -1 for web objects anyway — the
+                    // connection-owner pid from the daemon is the browser
+                    // process itself, which is exactly what the engine's
+                    // /proc marker checks need.
+                    int procId = queryConnectionPid(bus, sender);
                     focusProcessId_.store(procId,
                                           std::memory_order_relaxed);
+                    // Per-element pid (renderer pid on old Chrome) —
+                    // log/analysis signal only, not consumed by the
+                    // engine.  Web content only: browser-UI GetProcessId
+                    // can stall the shared monitor thread.
+                    int elemPid = hasDocWeb
+                                      ? queryElementPid(bus, sender, path)
+                                      : -1;
+                    focusElementPid_.store(elemPid,
+                                           std::memory_order_relaxed);
                     bool isUI = !hasDocWeb;
                     // Track whether the focused element is a real text
                     // entry (role TEXT / ENTRY / DOCUMENT_TEXT).  A
@@ -889,10 +902,10 @@ void A11yMonitor::threadFunc() {
                         std::memory_order_relaxed);
                     A11Y_LOG("Focus: webDoc=%d role=%d(%s) editable=%d "
                              "multiline=%d singleLine=%d states=[%s] "
-                             "pid=%d path=%s",
+                             "pid=%d elemPid=%d path=%s",
                              hasDocWeb, role, roleName(role), editable,
                              multiline, singleLine, states.c_str(), procId,
-                             path);
+                             elemPid, path);
                     // Track the focused text entry so the engine can
                     // query its content directly at replacement time.
                     static constexpr int ROLE_ENTRY = 79;

--- a/src/a11y_monitor.cpp
+++ b/src/a11y_monitor.cpp
@@ -401,11 +401,25 @@ static const char *roleName(int role) {
     }
 }
 
+// FB-specific ancestor-chain signatures (X11 routing: chat → Surr,
+// comment/other inputs → Uinput).  The chat composer's chain carries
+// FB_CHAT_ROLE_A immediately followed by FB_CHAT_ROLE_B (observed 3/3
+// sessions); the comment box carries FB_COMMENT_ROLE (2/2).  Stable
+// across tree rebuilds within a session.  Both extracted during the
+// document-web ancestor walk.
+static constexpr int FB_CHAT_ROLE_A = 87;
+static constexpr int FB_CHAT_ROLE_B = 16;
+static constexpr int FB_COMMENT_ROLE = 39;
+
 static bool hasDocumentWebAncestor(DBusConnection *bus,
                                    const char *sender,
-                                   const char *path) {
+                                   const char *path,
+                                   bool &chatSig, bool &commentSig) {
     std::string curSender = sender;
     std::string curPath = path;
+    chatSig = false;
+    commentSig = false;
+    int prevRole = -1;
 
     for (int depth = 0; depth < MAX_ANCESTOR_DEPTH; ++depth) {
         std::string parentSender, parentPath;
@@ -420,6 +434,11 @@ static bool hasDocumentWebAncestor(DBusConnection *bus,
         int role = queryRole(bus, parentSender.c_str(), parentPath.c_str());
         A11Y_LOG("  ancestor[%d]: role=%d path=%s", depth, role,
                  parentPath.c_str());
+        if (prevRole == FB_CHAT_ROLE_A && role == FB_CHAT_ROLE_B)
+            chatSig = true;
+        if (role == FB_COMMENT_ROLE)
+            commentSig = true;
+        prevRole = role;
         if (role == ROLE_DOCUMENT_WEB || role == ROLE_DOCUMENT_FRAME)
             return true;
 
@@ -836,8 +855,13 @@ void A11yMonitor::threadFunc() {
                 const char *path = dbus_message_get_path(msg);
                 if (sender && path) {
                     int role = queryRole(bus, sender, path);
+                    bool fbChatSig = false, fbCommentSig = false;
                     bool hasDocWeb = hasDocumentWebAncestor(
-                        bus, sender, path);
+                        bus, sender, path, fbChatSig, fbCommentSig);
+                    focusFbChatSig_.store(fbChatSig,
+                                          std::memory_order_relaxed);
+                    focusFbCommentSig_.store(fbCommentSig,
+                                             std::memory_order_relaxed);
                     // Resolve the pid through the D-Bus daemon for every
                     // focus event (web content included).  GetProcessId on
                     // Chromium's a11y objects stalls on browser-UI

--- a/src/a11y_monitor.h
+++ b/src/a11y_monitor.h
@@ -63,8 +63,17 @@ public:
     /// PID of the process serving the last focused accessible (-1 when
     /// unknown).  Captured on the monitor thread during focus events so
     /// the engine can run pid-targeted /proc checks instead of full scans.
+    /// Resolved via the D-Bus daemon (connection owner) — never stalls.
     int focusProcessId() const {
         return focusProcessId_.load(std::memory_order_relaxed);
+    }
+
+    /// Per-ELEMENT pid from GetProcessId on the focused accessible (the
+    /// per-tab renderer pid on old Chrome; Chrome ≥150 native a11y
+    /// answers -1).  Web content only — browser-UI queries can stall.
+    /// Log/analysis signal only: NOT consumed by the engine.
+    int focusElementPid() const {
+        return focusElementPid_.load(std::memory_order_relaxed);
     }
 
     /// True when the last focus snapshot was a real text-entry element
@@ -147,6 +156,7 @@ private:
     std::atomic<int> focusRole_{0};
     std::atomic<bool> focusEditable_{false};
     std::atomic<int> focusProcessId_{-1};
+    std::atomic<int> focusElementPid_{-1};
     std::atomic<bool> focusMultiline_{false};
     std::atomic<bool> focusSingleLine_{false};
     std::atomic<bool> textEntryFocused_{false};

--- a/src/a11y_monitor.h
+++ b/src/a11y_monitor.h
@@ -76,6 +76,18 @@ public:
         return focusElementPid_.load(std::memory_order_relaxed);
     }
 
+    /// FB-specific ancestor-chain signatures (see FB_CHAT_ROLE_A/B and
+    /// FB_COMMENT_ROLE in a11y_monitor.cpp).  Captured on the same focus
+    /// event as the snapshot, so they share its freshness window.  X11
+    /// routing: the FB chat composer gets SurroundingText, comments and
+    /// other web editors stay on Uinput.
+    bool isFocusFbChatChain() const {
+        return focusFbChatSig_.load(std::memory_order_relaxed);
+    }
+    bool isFocusFbCommentChain() const {
+        return focusFbCommentSig_.load(std::memory_order_relaxed);
+    }
+
     /// True when the last focus snapshot was a real text-entry element
     /// (role TEXT / ENTRY / DOCUMENT_TEXT).  A Chromium tab whose focus is
     /// NOT a text entry (clicking a Google Sheets cell focuses the
@@ -157,6 +169,8 @@ private:
     std::atomic<bool> focusEditable_{false};
     std::atomic<int> focusProcessId_{-1};
     std::atomic<int> focusElementPid_{-1};
+    std::atomic<bool> focusFbChatSig_{false};
+    std::atomic<bool> focusFbCommentSig_{false};
     std::atomic<bool> focusMultiline_{false};
     std::atomic<bool> focusSingleLine_{false};
     std::atomic<bool> textEntryFocused_{false};

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -220,14 +220,17 @@ static constexpr uint64_t kNativeDeleteDeferredUsec = 5000;
 // past 40ms.  X11 browser BS need enough time for Chrome's renderer to
 // process the forwarded keys; 10ms fixed covers that without the EWMA
 // inflation (0ms loses characters when typing fast, 15ms+ feels laggy).
-static constexpr uint64_t kX11BsForwardDeferredUsec = 8000; // 8ms (was 10ms —
-                                                             // less BS→commit flicker; watch for char loss on very fast typing)
-// X11 Chromium-family Uinput floor: the sync-anchor RT only measures the
+static constexpr uint64_t kX11BsForwardDeferredUsec = 10000; // 10ms — back to
+                                                             // the tuned safe minimum: 8ms lost chars on Mint's slower renderer
+                                                             // (the forwarded BS ate the deferred commit, "gõ" → "g")
+// X11 Chromium-family Uinput floors: the sync-anchor RT only measures the
 // browser-process IM loopback, NOT the renderer's BS processing — machines
 // with fast loopbacks (Mint: RT 3-7ms) derive sleeps of 4-7ms and lose
 // chars constantly (commit lands before the renderer processed the BS).
-// Flat 20ms — the level the user validated as smooth on Facebook
-// (matches Lotus's "Uinput (Chậm)" fixed 20ms).
+// Per-input (Auto looks at the input): FB-page inputs (ancestor-chain
+// signatures) get 20ms — the FB renderer is heavy; everything else keeps
+// a low 10ms floor.
+static constexpr uint64_t kChromeX11CommitDelayMinUsec = 10000;
 static constexpr uint64_t kFbX11CommitDelayMinUsec = 20000;
 // FB Surr deferred (experiment): 15ms — between the 10ms tuned safe
 // minimum and the 20ms that felt slow; the same-channel D-Bus ordering
@@ -2618,17 +2621,18 @@ bool SKeyState::handlePendingUinputBackspace(KeyEvent &keyEvent) {
       multiplier *= timing.chromiumDelayFactor;
       minDelay = static_cast<uint64_t>(minDelay * timing.chromiumDelayFactor);
       maxDelay = static_cast<uint64_t>(maxDelay * timing.chromiumDelayFactor);
-      // Floor on X11: see kFbX11CommitDelayMinUsec — a fast loopback
-      // must not shrink the sleep below what the renderer needs.  FLAT
-      // 20ms for every Chromium-family input: Uinput is the fallback
-      // mode that runs precisely when the a11y snapshot is NOT fresh
-      // yet, so the per-input chain signatures are never reliable here
-      // (observed: the first word after a click slept 16ms with no FB
-      // signature and the feel mismatched the Surr words).  The per-
-      // input split lives only in the Surr path (x11ChromiumSurrDelayUsec),
-      // where the FB-chat gate guarantees the signature exists.
+      // Floor on X11, per-input: the FB ancestor-chain signatures select
+      // the heavier 20ms floor for FB-page inputs; everything else keeps
+      // the low 10ms.  (When the signature is not yet available — right
+      // after a click — the low floor applies for that first word;
+      // acceptable: the a11y focus event usually lands before the first
+      // tone key.)
       if (!isWayland()) {
-        minDelay = std::max(minDelay, kFbX11CommitDelayMinUsec);
+        auto *chainMon = engine_->a11yMonitor();
+        bool fbInput = chainMon && (chainMon->isFocusFbChatChain() ||
+                                    chainMon->isFocusFbCommentChain());
+        minDelay = std::max(minDelay, fbInput ? kFbX11CommitDelayMinUsec
+                                              : kChromeX11CommitDelayMinUsec);
       }
     } else if (isWayland()) {
       // Native Wayland apps: the commit delay scales with the number of

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1429,9 +1429,18 @@ bool SKeyState::inChromiumAddressBar() const {
     // while still latching off after a real focus change.
     if (addrBarUiVerdictAtUsec_ != 0 &&
         now(CLOCK_MONOTONIC) - addrBarUiVerdictAtUsec_ <= 5000000) {
-      return true;
+      // A WIDE caret proves a real editor is focused (the FB search box
+      // can momentarily report a thin IME caret during delete/retype
+      // churn and latch the verdict — the hijack in the 03:07 trace
+      // where "chào" became "hào").  Clear the latch instead.
+      if (ic_->cursorRect().width() > 2) {
+        addrBarUiVerdictAtUsec_ = 0;
+      } else {
+        return true;
+      }
+    } else {
+      addrBarUiVerdictAtUsec_ = 0;
     }
-    addrBarUiVerdictAtUsec_ = 0;
     // Deterministic fallback (no a11y needed): the omnibox cursor rect
     // is a thin 1×~20 sliver near the window top, while Chrome content
     // editors report wider rects or (0,0,0x0).  This keeps the address
@@ -4208,8 +4217,16 @@ void SKeyState::keyEvent(KeyEvent &keyEvent) {
         // An EMPTY snapshot is not desync evidence — Chrome on some
         // distros (Fedora) returns an empty omnibox text while the word
         // is clearly on screen; resetting on it breaks every retype
-        // after a backspace.
-        if (mon && !txt.empty() && txt.find(comp) == std::string::npos) {
+        // after a backspace.  Likewise a snapshot containing only
+        // U+FFFC (object replacement — Chromium's a11y placeholder for
+        // an EMPTY editable, e.g. the FB search box): it fooled the
+        // empty check and reset the composition mid-retype ("chào" →
+        // "hào", 03:07 trace).
+        bool placeholderOnly = (txt == "\xEF\xBF\xBD"); // U+FFFC = Chromium's
+                                                        // a11y placeholder for
+                                                        // an EMPTY editable
+        if (mon && !txt.empty() && !placeholderOnly &&
+            txt.find(comp) == std::string::npos) {
           SKEY_DEBUG() << "AddrBar: desync — bar text '" << txt
                        << "' lacks composed '" << comp << "', resetting";
           viet_.reset();

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -391,12 +391,31 @@ static std::string userPkgDataDir() {
 // Matches actual Chromium-family browser programs.
 // Used ONLY for address-bar detection — electron/tabby must NOT match here
 // or non-browser Electron apps are misidentified as Chrome address bar.
-static bool isLibreOfficeApp(const std::string &prog) {
-  return prog.find("soffice") != std::string::npos ||
-         prog.find("libreoffice") != std::string::npos ||
-         prog.find("loimpress") != std::string::npos ||
-         prog.find("lowriter") != std::string::npos ||
-         prog.find("localc") != std::string::npos;
+// Office suites with broken SurroundingText implementations (X11-only
+// routing exception, user decision 2026-09-08): LibreOffice's VCL and
+// WPS/OnlyOffice process the fallback's forwarded BS asynchronously and
+// type wrong through Surr.  The a11y signals cannot distinguish them
+// from healthy apps (Telegram has the identical invalid-surrounding
+// signature), so these are name-matched — the pragmatic exception to
+// the input-driven philosophy.
+static bool isOfficeSuiteApp(const std::string &prog) {
+  std::string p = prog;
+  std::transform(p.begin(), p.end(), p.begin(), ::tolower);
+  // LibreOffice family
+  if (p.find("soffice") != std::string::npos ||
+      p.find("libreoffice") != std::string::npos ||
+      p.find("loimpress") != std::string::npos ||
+      p.find("lowriter") != std::string::npos ||
+      p.find("localc") != std::string::npos)
+    return true;
+  // WPS Office family (exact binary names — "et" is too generic for find)
+  if (p == "wps" || p == "wpp" || p == "et" || p == "wpspdf")
+    return true;
+  // OnlyOffice
+  if (p.find("onlyoffice") != std::string::npos ||
+      p.find("desktopeditors") != std::string::npos)
+    return true;
+  return false;
 }
 
 static bool isChromiumBrowser(const std::string &prog) {
@@ -1732,17 +1751,16 @@ SKeyOutputMode SKeyState::detectAutoMode() const {
     clearEngineBareCapsSticky();
   }
 
-  auto caps = ic_->capabilityFlags();
-
-  // LibreOffice (X11): advertises the SurroundingText cap (0x52) but its
-  // surrounding cache is unreliable — stale data and the focus-loss
-  // auto-commit make replacements delete the wrong text ("gõ rất lỗi").
-  // Route to Uinput (user-validated 2026-09-08; the per-app override the
-  // user saved manually does the same — this makes Auto pick it up).
-  if (!isWayland() && isLibreOfficeApp(appProgram())) {
-    SKEY_DEBUG() << "Auto: LibreOffice (X11) → Uinput";
+  // Office suites (X11): LibreOffice/WPS/OnlyOffice advertise the
+  // SurroundingText cap but type wrong through it (async key processing
+  // breaks the fallback; a11y cannot tell them from healthy apps) —
+  // hardcoded exception per the user's call, X11-only.
+  if (!isWayland() && isOfficeSuiteApp(appProgram())) {
+    SKEY_DEBUG() << "Auto: office suite (X11) → Uinput";
     return SKeyOutputMode::Uinput;
   }
+
+  auto caps = ic_->capabilityFlags();
 
   if (!caps.test(CapabilityFlag::SurroundingText)) {
     // Native Wayland apps (Telegram) often omit the SurroundingText cap
@@ -4983,6 +5001,8 @@ uint64_t SKeyState::x11ChromiumSurrDelayUsec() const {
   return fbInput ? kFbX11SurrDeferredUsec : kX11BsForwardDeferredUsec;
 }
 
+
+
 void SKeyState::surroundingCommit(const std::string &oldComposed,
                                   const std::string &newComposed) {
   if (newComposed.empty())
@@ -5114,11 +5134,22 @@ void SKeyState::surroundingCommit(const std::string &oldComposed,
             scheduleDeferredCommit(
                 addedPart, stablePrefix,
                 isWayland() ? 0 : x11ChromiumSurrDelayUsec());
+          } else if (!isWayland()) {
+            // X11 non-Chromium (LibreOffice, Telegram...): this lambda is
+            // the invalid-surrounding fallback.  The X server serializes
+            // key DELIVERY, but apps with asynchronous key processing
+            // (LO's VCL) still process the forwarded BS after the commit
+            // lands — the immediate commit raced them ("gõ rất lỗi" in
+            // LibreOffice, 2026-09-08).  Defer like the browser path;
+            // ~8ms per tone key is harmless for synchronous apps
+            // (Telegram) and fixes the asynchronous ones.
+            SKEY_DEBUG() << "Surr: deferred BS-forward '" << addedPart << "'";
+            scheduleDeferredCommit(addedPart, stablePrefix,
+                                   kX11BsForwardDeferredUsec);
           } else {
-            // X11 serializes forwarded BS and commitString through the
-            // X server; non-Chromium Wayland apps (Telegram etc.) process
-            // forwarded BS + commit in order — commit immediately, no
-            // extra latency.
+            // Non-Chromium Wayland apps (Telegram etc.) process forwarded
+            // BS + commit in order — commit immediately, no extra
+            // latency.
             commitText(addedPart);
           }
         }

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -1516,6 +1516,11 @@ static constexpr uint64_t kBareCapsDecisionWindowUsec = 2000000; // 2s
 // own keystroke is treated as the app's reaction (zen fires one after
 // every key), not a focus change.
 static constexpr uint64_t kSurrReattachWindowUsec = 500000; // 500ms
+// Word-boundary mode re-eval trigger back-off: once the trigger has
+// re-evaluated and the verdict is stable, further trigger-driven
+// re-detection is suppressed for this long (in-window input changes
+// still invalidate via reset()/activate()).
+static constexpr uint64_t kTriggerBackoffUsec = 10000000; // 10s
 
 bool SKeyState::a11yFreshWebEditor() const {
   // Browsers only.  The signal means "the user just clicked a real web
@@ -2217,7 +2222,17 @@ void SKeyState::activate() {
   // Invalidate mode cache — new focus means caps/program may have changed.
   chromiumBareCapsUinput_ = false;
   focusSawContentHints_ = false;
-  modeCacheValid_ = false;
+  // Spurious-cycle preservation (X11 Chromium): a deactivate→activate
+  // round trip within 500ms of the same window is Chrome's focus churn,
+  // not an input change — re-running the full detectAutoMode chain per
+  // flicker (measured 15 evaluations across a few activations) is pure
+  // waste.  Keep the cached mode; in-window input moves go through
+  // reset() (which invalidates), and genuine app switches are >500ms.
+  if (!(!isWayland() && isChromiumCached() && lastDeactivateTime_ > 0 &&
+        (now(CLOCK_MONOTONIC) - lastDeactivateTime_) < 500000)) {
+    modeCacheValid_ = false;
+  }
+  triggerBackoffUntilUsec_ = 0;
   cachedIsChromium_ = -1;
   cachedIsFirefoxOrSnap_ = -1;
   cachedIsTerminalApp_ = -1;
@@ -3024,13 +3039,26 @@ void SKeyState::keyEvent(KeyEvent &keyEvent) {
   // Uinput yet.
   bool a11yNonEntry = a11yBrowserNonEntryNarrow();
   bool a11yTerminal = a11yChromiumTerminal();
-  if (viet_.getRawInput().empty() &&
-      (modeDecisionPending_ || a11yFreshWebEditor() ||
-       (a11yNonEntry &&
-        (!modeCacheValid_ || cachedMode_ != SKeyOutputMode::Uinput)) ||
-       (a11yTerminal &&
-        (!modeCacheValid_ || cachedMode_ != SKeyOutputMode::Uinput)))) {
+  bool triggerHit =
+      modeDecisionPending_ || a11yFreshWebEditor() ||
+      (a11yNonEntry &&
+       (!modeCacheValid_ || cachedMode_ != SKeyOutputMode::Uinput)) ||
+      (a11yTerminal &&
+       (!modeCacheValid_ || cachedMode_ != SKeyOutputMode::Uinput));
+  // Back-off: the a11y triggers above re-evaluate the mode at every word
+  // boundary even when the verdict is stable (measured 31 detectAutoMode
+  // runs for 16 keystrokes in one Chrome input).  Re-check at most every
+  // kTriggerBackoffUsec once the mode is decided; in-window input changes
+  // still invalidate via reset()/activate(), and the bare-caps deferral
+  // (modeDecisionPending_) is never backed off — its 2s window must
+  // catch the caps upgrade in time.
+  if (viet_.getRawInput().empty() && triggerHit &&
+      (modeDecisionPending_ || !modeCacheValid_ ||
+       now(CLOCK_MONOTONIC) >= triggerBackoffUntilUsec_)) {
     modeCacheValid_ = false;
+    if (!modeDecisionPending_) {
+      triggerBackoffUntilUsec_ = now(CLOCK_MONOTONIC) + kTriggerBackoffUsec;
+    }
   }
 
   // Track current word state so reclaim targets the right word

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -2638,18 +2638,25 @@ bool SKeyState::handlePendingUinputBackspace(KeyEvent &keyEvent) {
       multiplier *= timing.chromiumDelayFactor;
       minDelay = static_cast<uint64_t>(minDelay * timing.chromiumDelayFactor);
       maxDelay = static_cast<uint64_t>(maxDelay * timing.chromiumDelayFactor);
-      // Floor on X11, per-input: the FB ancestor-chain signatures select
-      // the heavier 20ms floor for FB-page inputs; everything else keeps
-      // the low 10ms.  (When the signature is not yet available — right
-      // after a click — the low floor applies for that first word;
-      // acceptable: the a11y focus event usually lands before the first
-      // tone key.)
+      // Floor on X11, per-input.  The heavy floor applies to:
+      //   - FB-page inputs (ancestor-chain signatures, where available),
+      //   - any FRESH web-editor focus (role + line-state — portable,
+      //     works on every machine unlike the chain shapes; Mint's FB
+      //     a11y tree differs and the signatures never fire there),
+      //   - UNKNOWN inputs (no fresh snapshot yet — right after a click
+      //     or on machines where the a11y events lag): conservative.
+      // Only a fresh NON-editor snapshot (Sheets cell, browser UI)
+      // selects the low floor.
       if (!isWayland()) {
         auto *chainMon = engine_->a11yMonitor();
         bool fbInput = chainMon && (chainMon->isFocusFbChatChain() ||
                                     chainMon->isFocusFbCommentChain());
-        minDelay = std::max(minDelay, fbInput ? kFbX11CommitDelayMinUsec
-                                              : kChromeX11CommitDelayMinUsec);
+        bool freshWebEditor = a11yFreshWebEditor();
+        bool unknownInput =
+            !(chainMon && chainMon->isFocusSnapshotFresh(5000000));
+        bool slowInput = fbInput || freshWebEditor || unknownInput;
+        minDelay = std::max(minDelay, slowInput ? kFbX11CommitDelayMinUsec
+                                                : kChromeX11CommitDelayMinUsec);
       }
     } else if (isWayland()) {
       // Native Wayland apps: the commit delay scales with the number of

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -231,7 +231,8 @@ static constexpr uint64_t kX11BsForwardDeferredUsec = 10000; // 10ms — back to
 // signatures) get 20ms — the FB renderer is heavy; everything else keeps
 // a low 10ms floor.
 static constexpr uint64_t kChromeX11CommitDelayMinUsec = 10000;
-static constexpr uint64_t kFbX11CommitDelayMinUsec = 20000;
+static constexpr uint64_t kFbX11CommitDelayMinUsec = 25000; // 25ms (was 20ms —
+                                                             // still losing chars on FB chat in fast typing)
 // FB Surr deferred (experiment): 15ms — between the 10ms tuned safe
 // minimum and the 20ms that felt slow; the same-channel D-Bus ordering
 // keeps the loss risk low (the sleep only covers the app's processing).
@@ -1395,10 +1396,26 @@ bool SKeyState::inChromiumAddressBar() const {
       return false;
     }
     if (mon && mon->isBrowserUIFocused()) {
-      // Fresh true verdict — remember when so a lagging monitor can't
-      // flip the decision mid-word.
-      addrBarUiVerdictAtUsec_ = now(CLOCK_MONOTONIC);
-      return true;
+      // Only a FRESH browser-UI verdict counts, AND the caret must be
+      // addrbar-shaped.  Web-page buttons (FB's own UI) also produce
+      // fresh webDoc=0 button events — indistinguishable from the
+      // omnibox by a11y alone (Mint traces 02:16/02:18: the addrbar
+      // machinery hijacked the chat — extra autofill BS + desync
+      // resets, "mất chữ liên tục") — but the caret disambiguates: the
+      // omnibox is a thin sliver near the window top (1×~20), web
+      // editors report wide carets (FB chat 81×17).  Without a11y the
+      // deterministic cursor-rect fallback below still covers the real
+      // omnibox.  X11-only (this whole branch is !isWayland()).
+      if (mon->isFocusSnapshotFresh(5000000)) {
+        const auto &rect = ic_->cursorRect();
+        bool addrbarShaped = rect.width() <= 2 && rect.height() >= 18 &&
+                             rect.height() <= 24 && rect.top() >= 0 &&
+                             rect.top() < 200;
+        if (addrbarShaped) {
+          addrBarUiVerdictAtUsec_ = now(CLOCK_MONOTONIC);
+          return true;
+        }
+      }
     }
     // Grace window: the monitor processes focus events asynchronously
     // and Chrome's omnibox churn (dropdown open/close, suggestion

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -5155,22 +5155,21 @@ void SKeyState::surroundingCommit(const std::string &oldComposed,
             scheduleDeferredCommit(
                 addedPart, stablePrefix,
                 isWayland() ? 0 : x11ChromiumSurrDelayUsec());
-          } else if (!isWayland()) {
-            // X11 non-Chromium (LibreOffice, Telegram...): this lambda is
-            // the invalid-surrounding fallback.  The X server serializes
-            // key DELIVERY, but apps with asynchronous key processing
-            // (LO's VCL) still process the forwarded BS after the commit
-            // lands — the immediate commit raced them ("gõ rất lỗi" in
-            // LibreOffice, 2026-09-08).  Defer like the browser path;
-            // ~8ms per tone key is harmless for synchronous apps
-            // (Telegram) and fixes the asynchronous ones.
+          } else if (!isWayland() && isOfficeSuiteApp(appProgram())) {
+            // X11 OFFICE SUITES only (LibreOffice/WPS/OnlyOffice): the
+            // invalid-surrounding fallback.  Their async key processing
+            // (LO's VCL) processes the forwarded BS after an immediate
+            // commit lands ("gõ rất lỗi") — defer like the browser path.
             SKEY_DEBUG() << "Surr: deferred BS-forward '" << addedPart << "'";
             scheduleDeferredCommit(addedPart, stablePrefix,
                                    kX11BsForwardDeferredUsec);
           } else {
-            // Non-Chromium Wayland apps (Telegram etc.) process forwarded
-            // BS + commit in order — commit immediately, no extra
-            // latency.
+            // X11 non-Chromium apps (Telegram etc.) and non-Chromium
+            // Wayland apps process forwarded BS + commit in order (the
+            // X server serializes delivery) — commit immediately, no
+            // extra latency (Telegram's validated lag-free path; the
+            // blanket deferral added a felt 10ms per tone key,
+            // 2026-09-08).
             commitText(addedPart);
           }
         }

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -808,8 +808,12 @@ SKeyEngine::SKeyEngine(Instance *instance)
     : instance_(instance), factory_([this](InputContext &ic) -> SKeyState * {
         return new SKeyState(this, &ic);
       }) {
-  reloadConfig();
+  // Register BEFORE reloadConfig(): its per-IC invalidation iterates ICs
+  // and calls propertyFor(&factory_), which asserts the factory is
+  // registered on the manager — at startup an IC can already exist
+  // (portal monitor query) before the addon constructor finishes.
   instance_->inputContextManager().registerProperty("skeyState", &factory_);
+  reloadConfig();
   setupTrayMenu();
 
   // Start AT-SPI2 monitor for Chromium address bar detection.
@@ -1132,6 +1136,22 @@ void SKeyEngine::reloadConfig() {
   std::string modeStr = outputModeName(config_.outputMode.value());
   SKEY_INFO() << "Config: outputMode=" << modeStr
               << " debug(from file)=" << g_skeyDebugEnabled;
+
+  // The settings app rewrites conf/skey-app-modes.conf without an IC
+  // activation — the currently focused IC would otherwise keep its stale
+  // per-app override until the next focus cycle.  Invalidate every live
+  // IC's cached program key so refreshAppMode() re-reads the file on the
+  // next effectiveMode() call.  Mid-word ICs keep their mode until the
+  // word boundary — Auto's decision must never flip the composition path
+  // half-way through.  (foreach visits only live ICs — never
+  // lastFocusedInputContext(), which can dangle during startup focus
+  // churn and trips the manager assert in propertyFor().)
+  instance_->inputContextManager().foreach([this](InputContext *ic) {
+    if (auto *state = ic->propertyFor(&factory_)) {
+      state->invalidateAppModeOverrideCache();
+    }
+    return true;
+  });
 }
 
 std::string SKeyEngine::subMode(const InputMethodEntry &entry,
@@ -1255,6 +1275,15 @@ const std::string &SKeyState::appProgram() const {
                 << "'";
   }
   return resolvedProgram_;
+}
+
+void SKeyState::invalidateAppModeOverrideCache() {
+  // Sentinel (≠ any real program name, including empty) forces
+  // refreshAppMode() to re-read conf/skey-app-modes.conf.
+  cachedProgram_ = "\x01";
+  if (viet_.getRawInput().empty()) {
+    modeCacheValid_ = false;
+  }
 }
 
 void SKeyState::refreshAppMode() {
@@ -1630,7 +1659,25 @@ SKeyOutputMode SKeyState::detectAutoMode() const {
   // editor's strong hints (e.g. 0x90072 from a chat box) — typing would go
   // nowhere.  Requires a FRESH snapshot: without one we cannot conclude
   // anything and fall back to the cap-based decision below.
-  if (a11yBrowserNonEntry()) {
+  bool nonEntry = a11yBrowserNonEntry();
+  // Non-entry flicker guard (X11 Chrome): the broad check is the
+  // activation-time safe default, but X11 Chrome has NO caps-based
+  // recovery — a transient non-entry focus (combo_box/button UI noise
+  // when re-clicking the chat) would drop a web editor back to Uinput
+  // permanently (21:59:08 repro: role=11 combo_box flipped FB chat).
+  // When this IC already resolved to Surr (only the X11 web-editor
+  // route can produce Surr here — overrides bypass detectAutoMode),
+  // treat non-text-entry ROLES as noise and keep Surr; the Sheets cell
+  // signature (text-entry role + editable=0 + no line state, the narrow
+  // check) still flips to Uinput.  The address bar keeps its own Uinput
+  // machinery and is excluded.
+  if (nonEntry && cachedMode_ == SKeyOutputMode::SurroundingText &&
+      !isWayland() && isChromiumCached() && isChromiumBrowser(appProgram()) &&
+      !inChromiumAddressBar() && !a11yBrowserNonEntryNarrow()) {
+    SKEY_DEBUG() << "Auto: non-entry flicker over X11 web editor, keep Surr";
+    return SKeyOutputMode::SurroundingText;
+  }
+  if (nonEntry) {
     SKEY_DEBUG() << "Auto: focus is not a text entry → Uinput";
     return SKeyOutputMode::Uinput;
   }
@@ -1670,6 +1717,22 @@ SKeyOutputMode SKeyState::detectAutoMode() const {
     // cache never arrives.
     if (waylandNativeSurroundingProbe()) {
       SKEY_DEBUG() << "Auto: no SurroundingText cap, probing SurroundingText";
+      return SKeyOutputMode::SurroundingText;
+    }
+    // X11 Chromium browsers NEVER advertise the SurroundingText cap (the
+    // GTK IM module only sets it when the client pushes surrounding text,
+    // and Chrome doesn't — caps stay 0x6000000032), so without this every
+    // Chrome input falls to Uinput.  A fresh a11y web-editor focus
+    // (Facebook chat: role ENTRY + single-line; excludes the Sheets cell
+    // signature and browser-UI — see a11yFreshWebEditor) routes to
+    // SurroundingText instead: the no-cap runtime fallback (forwardKey BS
+    // + deferred commit, "client has no surrounding text capability") is
+    // the validated Chromium web-editor path on X11.  If the fallback
+    // ever fails, noteSurroundingFailure() downgrades this IC straight
+    // back to Uinput (Chromium-family rule).
+    if (!isWayland() && a11yFreshWebEditor()) {
+      SKEY_DEBUG() << "Auto: X11 Chromium web editor, no Surr cap → "
+                      "SurroundingText";
       return SKeyOutputMode::SurroundingText;
     }
     SKEY_DEBUG() << "Auto: no SurroundingText cap → Uinput";
@@ -1819,8 +1882,21 @@ int SKeyState::a11yAppPid() const {
   if (!comm.empty() && comm.back() == '\n') {
     comm.pop_back();
   }
-  if (comm != prog && prog.compare(0, 15, comm) != 0 &&
-      comm.compare(0, 15, prog) != 0) {
+  bool commMatches = comm == prog || prog.compare(0, 15, comm) == 0 ||
+                     comm.compare(0, 15, prog) == 0;
+  // Chromium renames its main/renderer threads ("chrome", "CrRendererMain",
+  // ...), so the comm can never match a full program name like
+  // "google-chrome-stable" — accept the known Chromium thread names when
+  // the program is a Chromium browser (rejecting them killed the entire
+  // pid pipeline for Chrome even after the monitor-side fix, 2026-09-07).
+  if (!commMatches && isChromiumBrowser(prog) &&
+      (comm == "chrome" || comm == "CrRendererMain" ||
+       comm == "CrGpuMain" || comm == "CrUtilityMain")) {
+    commMatches = true;
+  }
+  if (!commMatches) {
+    SKEY_DEBUG() << "a11yAppPid: reject pid " << pid << " comm='" << comm
+                 << "' prog='" << prog << "'";
     return -1; // the focused accessible belongs to a different app
   }
   return pid;

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -233,6 +233,10 @@ static constexpr uint64_t kX11BsForwardDeferredUsec = 10000; // 10ms — back to
 static constexpr uint64_t kChromeX11CommitDelayMinUsec = 10000;
 static constexpr uint64_t kFbX11CommitDelayMinUsec = 25000; // 25ms (was 20ms —
                                                              // still losing chars on FB chat in fast typing)
+// First-word settle headroom: the renderer is still settling right after
+// a focus switch — the first heavy replace (long words like "ứng") and
+// the first immediate commit (del=0) lose chars at the normal timings.
+static constexpr uint64_t kFirstWordSettleUsec = 50000;
 // FB Surr deferred (experiment): 15ms — between the 10ms tuned safe
 // minimum and the 20ms that felt slow; the same-channel D-Bus ordering
 // keeps the loss risk low (the sleep only covers the app's processing).
@@ -2350,6 +2354,11 @@ void SKeyState::activate() {
                << " cursor=(" << ic_->cursorRect().left() << ","
                << ic_->cursorRect().top() << "," << ic_->cursorRect().width()
                << "x" << ic_->cursorRect().height() << ")";
+
+  // First-word settle tracking (see kFirstWordSettleUsec): the first
+  // replaces after this activation get extra commit headroom while the
+  // renderer settles into the new focus.
+  lastActivateUsec_ = now(CLOCK_MONOTONIC);
 }
 
 // Connect to a unix socket: filesystem path or abstract name (abstract =
@@ -2681,6 +2690,13 @@ bool SKeyState::handlePendingUinputBackspace(KeyEvent &keyEvent) {
                         : std::max(elapsed, bsRtEwma_ / 2);
   uint64_t sleepUsec = std::clamp(static_cast<uint64_t>(baseRt * multiplier),
                                   minDelay, maxDelay);
+  // First word after a focus switch: the renderer is settling — heavy
+  // first replaces (long words, "ứng") lose chars at the normal sleep.
+  // One-time extra headroom for the first second of the IC.
+  if (!isWayland() && isChromiumCached() && lastActivateUsec_ > 0 &&
+      now(CLOCK_MONOTONIC) - lastActivateUsec_ < 1000000) {
+    sleepUsec = std::max(sleepUsec, kFirstWordSettleUsec);
+  }
 
   if (uinputLoopbackSlow_) {
     // Previous replacement's loopbacks were slow — give the app extra
@@ -2747,13 +2763,6 @@ bool SKeyState::handlePendingUinputBackspace(KeyEvent &keyEvent) {
     }
     this->commitText(commitText);
   }
-  // Arm the late-BS grace window on EVERY committed replacement, not
-  // just the safety-timeout force-commit: Chromium's post-commit focus
-  // cycles re-deliver the injected BS (the sync anchor included) — a
-  // re-delivered BS arriving after the commit was treated as a user
-  // backspace and ate the commit's tail ("ứng" → "ứn" in the FB
-  // comment, 02:46 trace).  The grace swallows those loopbacks.
-  uinputLateBsDeadlineUsec_ = now(CLOCK_MONOTONIC) + 400000;
   if (uinputPendingFinalLen_ > 0) {
     committedLen_ = uinputPendingFinalLen_;
     uinputPendingFinalLen_ = 0;
@@ -4418,6 +4427,14 @@ void SKeyState::keyEvent(KeyEvent &keyEvent) {
                            << addPart << "'";
               if (inChromiumAddressBar())
                 addrBarExpectCycle_ = true;
+              // First key right after a focus switch: the renderer is
+              // still settling — the immediate commit (no BS, no sleep
+              // otherwise) drops or lands out of order with the next
+              // forwards ("ứng" first-word loss).  One-time settle.
+              if (!isWayland() && isChromiumCached() && lastActivateUsec_ > 0 &&
+                  now(CLOCK_MONOTONIC) - lastActivateUsec_ < 300000) {
+                usleep(kFirstWordSettleUsec);
+              }
               commitText(addPart);
             }
             committedLen_ = static_cast<int>(utf8::length(newComposed));

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -2747,6 +2747,13 @@ bool SKeyState::handlePendingUinputBackspace(KeyEvent &keyEvent) {
     }
     this->commitText(commitText);
   }
+  // Arm the late-BS grace window on EVERY committed replacement, not
+  // just the safety-timeout force-commit: Chromium's post-commit focus
+  // cycles re-deliver the injected BS (the sync anchor included) — a
+  // re-delivered BS arriving after the commit was treated as a user
+  // backspace and ate the commit's tail ("ứng" → "ứn" in the FB
+  // comment, 02:46 trace).  The grace swallows those loopbacks.
+  uinputLateBsDeadlineUsec_ = now(CLOCK_MONOTONIC) + 400000;
   if (uinputPendingFinalLen_ > 0) {
     committedLen_ = uinputPendingFinalLen_;
     uinputPendingFinalLen_ = 0;

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -220,7 +220,8 @@ static constexpr uint64_t kNativeDeleteDeferredUsec = 5000;
 // past 40ms.  X11 browser BS need enough time for Chrome's renderer to
 // process the forwarded keys; 10ms fixed covers that without the EWMA
 // inflation (0ms loses characters when typing fast, 15ms+ feels laggy).
-static constexpr uint64_t kX11BsForwardDeferredUsec = 10000;
+static constexpr uint64_t kX11BsForwardDeferredUsec = 8000; // 8ms (was 10ms —
+                                                             // less BS→commit flicker; watch for char loss on very fast typing)
 
 // Uinput commit-delay for non-Chromium apps on native Wayland.  The anchor
 // loopback proves fcitx5 saw the BS, not that the app processed them — Qt
@@ -4866,10 +4867,20 @@ void SKeyState::flushDeferredCommit() {
   }
 
   // Enforce adaptive minimum delay between BackSpace and commit.
-  uint64_t minGapUsec =
-      (bsRtEwma_ > 0 && bsRtEwma_ != uinputTiming().bsRtInitialUsec)
-          ? std::max(bsRtEwma_ * 2 + 8000, dbusDeferredMinUsec)
-          : dbusDeferredDefaultUsec;
+  // X11 Chromium browsers use the FIXED kX11BsForwardDeferredUsec —
+  // the adaptive EWMA (inflated by a prior Uinput session on the same
+  // IC) or the 15ms default overshoots the 10ms schedule and stretches
+  // the visible BS→commit flicker at word boundaries.
+  uint64_t minGapUsec;
+  if (!isWayland() && isChromiumCached() && isChromiumBrowser(appProgram()) &&
+      !inChromiumAddressBar()) {
+    minGapUsec = kX11BsForwardDeferredUsec;
+  } else {
+    minGapUsec =
+        (bsRtEwma_ > 0 && bsRtEwma_ != uinputTiming().bsRtInitialUsec)
+            ? std::max(bsRtEwma_ * 2 + 8000, dbusDeferredMinUsec)
+            : dbusDeferredDefaultUsec;
+  }
   if (deferredBsSentAt_ > 0) {
     uint64_t nowUs = now(CLOCK_MONOTONIC);
     uint64_t elapsed = nowUs - deferredBsSentAt_;
@@ -5028,6 +5039,13 @@ void SKeyState::surroundingCommit(const std::string &oldComposed,
         for (int i = 0; i < deleteLen; ++i) {
           ic_->forwardKey(Key(FcitxKey_BackSpace));
         }
+        // Record when the BS were forwarded — flushDeferredCommit()'s
+        // safety guard needs this timestamp to know whether the app has
+        // had time to process them.  It was NEVER set before, so the
+        // guard was dead code and a flush on the next fast key committed
+        // immediately — the in-flight BS then ate the committed text
+        // ("bộ" → "bo", observed 2026-09-07).
+        deferredBsSentAt_ = now(CLOCK_MONOTONIC);
         committedLen_ = newLen;
         if (!addedPart.empty()) {
           if ((isWayland() && (isChromiumCached() || isFirefoxOrSnap())) ||

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -222,6 +222,17 @@ static constexpr uint64_t kNativeDeleteDeferredUsec = 5000;
 // inflation (0ms loses characters when typing fast, 15ms+ feels laggy).
 static constexpr uint64_t kX11BsForwardDeferredUsec = 8000; // 8ms (was 10ms —
                                                              // less BS→commit flicker; watch for char loss on very fast typing)
+// X11 Chromium-family Uinput floor: the sync-anchor RT only measures the
+// browser-process IM loopback, NOT the renderer's BS processing — machines
+// with fast loopbacks (Mint: RT 3-7ms) derive sleeps of 4-7ms and lose
+// chars constantly (commit lands before the renderer processed the BS).
+// Flat 20ms — the level the user validated as smooth on Facebook
+// (matches Lotus's "Uinput (Chậm)" fixed 20ms).
+static constexpr uint64_t kFbX11CommitDelayMinUsec = 20000;
+// FB Surr deferred (experiment): 15ms — between the 10ms tuned safe
+// minimum and the 20ms that felt slow; the same-channel D-Bus ordering
+// keeps the loss risk low (the sleep only covers the app's processing).
+static constexpr uint64_t kFbX11SurrDeferredUsec = 15000;
 
 // Uinput commit-delay for non-Chromium apps on native Wayland.  The anchor
 // loopback proves fcitx5 saw the BS, not that the app processed them — Qt
@@ -380,6 +391,14 @@ static std::string userPkgDataDir() {
 // Matches actual Chromium-family browser programs.
 // Used ONLY for address-bar detection — electron/tabby must NOT match here
 // or non-browser Electron apps are misidentified as Chrome address bar.
+static bool isLibreOfficeApp(const std::string &prog) {
+  return prog.find("soffice") != std::string::npos ||
+         prog.find("libreoffice") != std::string::npos ||
+         prog.find("loimpress") != std::string::npos ||
+         prog.find("lowriter") != std::string::npos ||
+         prog.find("localc") != std::string::npos;
+}
+
 static bool isChromiumBrowser(const std::string &prog) {
   static const char *const patterns[] = {
       "chrome",  "chromium",       "google-chrome", "brave",
@@ -1715,6 +1734,16 @@ SKeyOutputMode SKeyState::detectAutoMode() const {
 
   auto caps = ic_->capabilityFlags();
 
+  // LibreOffice (X11): advertises the SurroundingText cap (0x52) but its
+  // surrounding cache is unreliable — stale data and the focus-loss
+  // auto-commit make replacements delete the wrong text ("gõ rất lỗi").
+  // Route to Uinput (user-validated 2026-09-08; the per-app override the
+  // user saved manually does the same — this makes Auto pick it up).
+  if (!isWayland() && isLibreOfficeApp(appProgram())) {
+    SKEY_DEBUG() << "Auto: LibreOffice (X11) → Uinput";
+    return SKeyOutputMode::Uinput;
+  }
+
   if (!caps.test(CapabilityFlag::SurroundingText)) {
     // Native Wayland apps (Telegram) often omit the SurroundingText cap
     // on the compositor text-input path even though they push surrounding
@@ -1727,20 +1756,16 @@ SKeyOutputMode SKeyState::detectAutoMode() const {
     }
     // X11 Chromium browsers NEVER advertise the SurroundingText cap (the
     // GTK IM module only sets it when the client pushes surrounding text,
-    // and Chrome doesn't — caps stay 0x6000000032), so without this every
-    // Chrome input falls to Uinput.  A fresh a11y web-editor focus
-    // (Facebook chat: role ENTRY + single-line; excludes the Sheets cell
-    // signature and browser-UI — see a11yFreshWebEditor) routes to
-    // SurroundingText instead: the no-cap runtime fallback (forwardKey BS
-    // + deferred commit, "client has no surrounding text capability") is
-    // the validated Chromium web-editor path on X11.  If the fallback
-    // ever fails, noteSurroundingFailure() downgrades this IC straight
-    // back to Uinput (Chromium-family rule).
-    if (!isWayland() && a11yFreshWebEditor()) {
-      SKEY_DEBUG() << "Auto: X11 Chromium web editor, no Surr cap → "
-                      "SurroundingText";
-      return SKeyOutputMode::SurroundingText;
-    }
+    // and Chrome doesn't — caps stay 0x6000000032), so EVERY Chrome input
+    // falls to Uinput on X11.  That is the desired behavior for the whole
+    // FB page (chat included): with the 20ms Uinput floor the FB renderer
+    // types loss-free, and the previous FB-chat→Surr route was removed
+    // (2026-09-08) — the Surr no-cap fallback's step-wise forwardKey
+    // deletion felt slower than the Uinput kernel BS batch, and the
+    // per-input delay split it enabled is not worth the mode flips.
+    // The FB ancestor-chain signatures are still captured by the monitor
+    // (used by x11ChromiumSurrDelayUsec if Surr ever runs again via a
+    // manual override).
     SKEY_DEBUG() << "Auto: no SurroundingText cap → Uinput";
     return SKeyOutputMode::Uinput;
   }
@@ -2575,6 +2600,18 @@ bool SKeyState::handlePendingUinputBackspace(KeyEvent &keyEvent) {
       multiplier *= timing.chromiumDelayFactor;
       minDelay = static_cast<uint64_t>(minDelay * timing.chromiumDelayFactor);
       maxDelay = static_cast<uint64_t>(maxDelay * timing.chromiumDelayFactor);
+      // Floor on X11: see kFbX11CommitDelayMinUsec — a fast loopback
+      // must not shrink the sleep below what the renderer needs.  FLAT
+      // 20ms for every Chromium-family input: Uinput is the fallback
+      // mode that runs precisely when the a11y snapshot is NOT fresh
+      // yet, so the per-input chain signatures are never reliable here
+      // (observed: the first word after a click slept 16ms with no FB
+      // signature and the feel mismatched the Surr words).  The per-
+      // input split lives only in the Surr path (x11ChromiumSurrDelayUsec),
+      // where the FB-chat gate guarantees the signature exists.
+      if (!isWayland()) {
+        minDelay = std::max(minDelay, kFbX11CommitDelayMinUsec);
+      }
     } else if (isWayland()) {
       // Native Wayland apps: the commit delay scales with the number of
       // deletions (see kWaylandNativeCommitDelayPerBsUsec) — keep a small
@@ -4867,14 +4904,15 @@ void SKeyState::flushDeferredCommit() {
   }
 
   // Enforce adaptive minimum delay between BackSpace and commit.
-  // X11 Chromium browsers use the FIXED kX11BsForwardDeferredUsec —
-  // the adaptive EWMA (inflated by a prior Uinput session on the same
-  // IC) or the 15ms default overshoots the 10ms schedule and stretches
-  // the visible BS→commit flicker at word boundaries.
+  // X11 Chromium browsers use the FIXED per-input delay (see
+  // x11ChromiumSurrDelayUsec) — the adaptive EWMA (inflated by a prior
+  // Uinput session on the same IC) or the 15ms default overshoots the
+  // schedule and stretches the visible BS→commit flicker at word
+  // boundaries.
   uint64_t minGapUsec;
   if (!isWayland() && isChromiumCached() && isChromiumBrowser(appProgram()) &&
       !inChromiumAddressBar()) {
-    minGapUsec = kX11BsForwardDeferredUsec;
+    minGapUsec = x11ChromiumSurrDelayUsec();
   } else {
     minGapUsec =
         (bsRtEwma_ > 0 && bsRtEwma_ != uinputTiming().bsRtInitialUsec)
@@ -4936,6 +4974,13 @@ void SKeyState::forceFlushDeferredCommit() {
   pendingFlushSuffix_.clear();
   deferredCommitTimer_.reset();
   commitText(toCommit);
+}
+
+uint64_t SKeyState::x11ChromiumSurrDelayUsec() const {
+  auto *chainMon = engine_->a11yMonitor();
+  bool fbInput = chainMon && (chainMon->isFocusFbChatChain() ||
+                              chainMon->isFocusFbCommentChain());
+  return fbInput ? kFbX11SurrDeferredUsec : kX11BsForwardDeferredUsec;
 }
 
 void SKeyState::surroundingCommit(const std::string &oldComposed,
@@ -5066,8 +5111,9 @@ void SKeyState::surroundingCommit(const std::string &oldComposed,
             // Electron apps on X11 keep the immediate commit (no race
             // reports there; leave the proven behavior alone).
             SKEY_DEBUG() << "Surr: deferred BS-forward '" << addedPart << "'";
-            scheduleDeferredCommit(addedPart, stablePrefix,
-                                   isWayland() ? 0 : kX11BsForwardDeferredUsec);
+            scheduleDeferredCommit(
+                addedPart, stablePrefix,
+                isWayland() ? 0 : x11ChromiumSurrDelayUsec());
           } else {
             // X11 serializes forwarded BS and commitString through the
             // X server; non-Chromium Wayland apps (Telegram etc.) process

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -2701,8 +2701,13 @@ bool SKeyState::handlePendingUinputBackspace(KeyEvent &keyEvent) {
                                   minDelay, maxDelay);
   // First word after a focus switch: the renderer is settling — heavy
   // first replaces (long words, "ứng") lose chars at the normal sleep.
-  // One-time extra headroom for the first second of the IC.
-  if (!isWayland() && isChromiumCached() && lastActivateUsec_ > 0 &&
+  // One-time extra headroom for the first second of the IC.  The
+  // ADDRESS BAR is excluded: its own machinery + timing are tuned
+  // separately, and the omnibox churn (Deactivate/Activate per
+  // keystroke) re-arms lastActivateUsec_ constantly — the 50ms
+  // headroom would apply to every replace and made the omnibox laggy.
+  if (!isWayland() && isChromiumCached() && !inChromiumAddressBar() &&
+      lastActivateUsec_ > 0 &&
       now(CLOCK_MONOTONIC) - lastActivateUsec_ < 1000000) {
     sleepUsec = std::max(sleepUsec, kFirstWordSettleUsec);
   }
@@ -4448,7 +4453,10 @@ void SKeyState::keyEvent(KeyEvent &keyEvent) {
               // still settling — the immediate commit (no BS, no sleep
               // otherwise) drops or lands out of order with the next
               // forwards ("ứng" first-word loss).  One-time settle.
-              if (!isWayland() && isChromiumCached() && lastActivateUsec_ > 0 &&
+              // Address bar excluded (omnibox churn re-arms the window
+              // constantly).
+              if (!isWayland() && isChromiumCached() &&
+                  !inChromiumAddressBar() && lastActivateUsec_ > 0 &&
                   now(CLOCK_MONOTONIC) - lastActivateUsec_ < 300000) {
                 usleep(kFirstWordSettleUsec);
               }

--- a/src/engine.h
+++ b/src/engine.h
@@ -176,6 +176,10 @@ private:
     // suppress trigger-driven mode re-detection while the verdict is
     // stable.  CLOCK_MONOTONIC, 0 = inactive.
     uint64_t triggerBackoffUntilUsec_ = 0;
+    // CLOCK_MONOTONIC timestamp of the most recent activate() — the
+    // first word after a focus switch gets extra settle headroom
+    // (kFirstWordSettleUsec) because the renderer is still settling.
+    uint64_t lastActivateUsec_ = 0;
     mutable int cachedIsChromium_ = -1;  // tristate: -1=unset, 0=false, 1=true
     // Sticky browser-UI verdict for X11: the a11y monitor may lag behind
     // keystrokes; keep the last true verdict for a short grace instead of

--- a/src/engine.h
+++ b/src/engine.h
@@ -40,6 +40,12 @@ public:
     void activate();
     void deactivate();
     void reset();
+    /// Called by SKeyEngine::reloadConfig() after the settings app
+    /// rewrote conf/skey-app-modes.conf: drop the cached program key so
+    /// refreshAppMode() re-reads the file, and invalidate the mode cache
+    /// unless the IC is mid-word (Auto must not flip the composition
+    /// path half-way through — the word-boundary trigger handles it).
+    void invalidateAppModeOverrideCache();
 
     // Mode switch menu (called from ModeCandidateWord)
     void dismissModeMenu();

--- a/src/engine.h
+++ b/src/engine.h
@@ -167,6 +167,10 @@ private:
     mutable std::string resolvedProgram_;
     mutable bool modeCacheValid_ = false;
     mutable SKeyOutputMode cachedMode_ = SKeyOutputMode::SurroundingText;
+    // Word-boundary re-eval trigger back-off (see kTriggerBackoffUsec):
+    // suppress trigger-driven mode re-detection while the verdict is
+    // stable.  CLOCK_MONOTONIC, 0 = inactive.
+    uint64_t triggerBackoffUntilUsec_ = 0;
     mutable int cachedIsChromium_ = -1;  // tristate: -1=unset, 0=false, 1=true
     // Sticky browser-UI verdict for X11: the a11y monitor may lag behind
     // keystrokes; keep the last true verdict for a short grace instead of

--- a/src/engine.h
+++ b/src/engine.h
@@ -46,6 +46,11 @@ public:
     /// unless the IC is mid-word (Auto must not flip the composition
     /// path half-way through — the word-boundary trigger handles it).
     void invalidateAppModeOverrideCache();
+    /// Per-input deferred-commit delay for the X11 Chromium no-cap Surr
+    /// fallback (forwardKey BS + deferred commit): FB-page inputs get the
+    /// same 20ms floor as the Uinput path (heavy renderer), other inputs
+    /// keep the low kX11BsForwardDeferredUsec.
+    uint64_t x11ChromiumSurrDelayUsec() const;
 
     // Mode switch menu (called from ModeCandidateWord)
     void dismissModeMenu();


### PR DESCRIPTION
- **fix: resolve process PID via D-Bus daemon to prevent AT-SPI stalls and ensure proper registration order of input context properties.**
- **perf: reduce redundant mode re-evaluations by implementing Chromium focus-churn deferral and word-boundary trigger back-off**
- **fix: reduce X11 Chromium backspace delay and enable deferred commit timestamping to prevent character deletion**
- **refactor: unify X11 Chromium input routing to Uinput with a 20ms commit floor and add LibreOffice app-specific detection**
- **refactor: extend X11 office suite exception to WPS and OnlyOffice and add mandatory commit deferral to resolve asynchronous key processing issues**
- **fix: introduce adaptive 10ms-20ms X11 commit floor based on per-input FB signature detection**
- **fix: increase FB X11 commit delay and add caret-shape validation for browser UI focus to prevent input desync**
- **fix: restrict deferred surrounding commits to X11 office suites to avoid latency in non-Chromium apps**
- **fix: refine X11 input delay logic to apply heavy floor to web-editor and unknown focus states**
- **fix: arm late-BS grace window on all replacements to prevent accidental tail deletion**
- **feat: implement first-word settle headroom for Chromium focus switches to prevent character loss**
- **fix: prevent address bar composition resets caused by IME cursor width and empty placeholder artifacts**
- **fix: prevent performance degradation in Chromium address bar by excluding it from first-word settle logic**
- **chore: bump project version to 0.8.2**
